### PR TITLE
Repool server client

### DIFF
--- a/src/prepack/createGraphicPack/index.ts
+++ b/src/prepack/createGraphicPack/index.ts
@@ -10,7 +10,7 @@ import zipDir from '../../utils/zipDir';
  * Create a graphic pack
  */
 export default async (metadata: PackMetadataType, config: ConfigType) => {
-  const SERVER_CLIENT = getServerClient();
+  const serverClient = getServerClient();
 
   const packMetadata = {
     rootSlug: metadata.graphic.slugs.root,
@@ -22,9 +22,6 @@ export default async (metadata: PackMetadataType, config: ConfigType) => {
     byline: metadata.contact.name,
     contactEmail: metadata.contact.email,
   };
-  // if (metadata.graphic.slugs.wild && metadata.graphic.slugs.wild !== '') {
-  //   packMetadata.wildSlug = metadata.graphic.slugs.wild;
-  // }
 
   const editionMetadata = {
     language: config.PACK_LOCALE,
@@ -32,9 +29,9 @@ export default async (metadata: PackMetadataType, config: ConfigType) => {
     description: metadata.description,
   };
 
-  await SERVER_CLIENT.createGraphic(packMetadata);
-  const pack = SERVER_CLIENT?.graphic?.id;
-  if (!pack) return;
+  await serverClient.createGraphic(packMetadata);
+  const pack = serverClient?.graphic?.id;
+  if (!pack) throw new Error('Did not get a graphic ID from the RNGS server');
 
   const PUBLIC_EDITION_DIR = path.join(config.PACK_DIR, 'public/interactive');
   fs.ensureDirSync(PUBLIC_EDITION_DIR);
@@ -46,7 +43,7 @@ export default async (metadata: PackMetadataType, config: ConfigType) => {
   await zipDir(path.join(config.PACK_DIR, 'public'));
   const fileBuffer = fs.readFileSync(path.join(config.PACK_DIR, 'public.zip'));
 
-  const editions = await SERVER_CLIENT.createEditions(
+  const editions = await serverClient.createEditions(
     'public.zip',
     fileBuffer,
     editionMetadata
@@ -70,5 +67,5 @@ export default async (metadata: PackMetadataType, config: ConfigType) => {
 
   fs.unlinkSync(path.join(config.PACK_DIR, 'public.zip'));
 
-  return { pack, url: standardisedURL };
+  return serverClient;
 };

--- a/src/prepack/getPackMetadata/schemas/authors.ts
+++ b/src/prepack/getPackMetadata/schemas/authors.ts
@@ -34,7 +34,7 @@ export default () =>
                 index
               )} author ${chalk.grey(`(${variablePath})`)}?`;
             },
-            initial: getProfileProp('url'),
+            initial: 'https://www.reuters.com/authors/',
           },
         },
       },

--- a/src/prepack/index.ts
+++ b/src/prepack/index.ts
@@ -6,8 +6,8 @@ import updateGraphicPack from './updateGraphicPack';
 export default async (config: ConfigType) => {
   const packMetadata = await getPackMetadata(config);
   if (!packMetadata.graphic.pack) {
-    await createGraphicPack(packMetadata, config);
+    return createGraphicPack(packMetadata, config);
   } else {
-    await updateGraphicPack(packMetadata, config);
+    return updateGraphicPack(packMetadata, config);
   }
 };

--- a/src/prepack/updateGraphicPack/index.ts
+++ b/src/prepack/updateGraphicPack/index.ts
@@ -9,7 +9,7 @@ import getServerClient from '../../utils/getServerClient';
  * Update a graphic pack
  */
 export default async (metadata: PackMetadataType, config: ConfigType) => {
-  const SERVER_CLIENT = getServerClient(metadata.graphic.pack);
+  const serverClient = getServerClient(metadata.graphic.pack);
 
   const packMetadata = {
     rootSlug: metadata.graphic.slugs.root,
@@ -21,12 +21,8 @@ export default async (metadata: PackMetadataType, config: ConfigType) => {
     byline: metadata.contact.name,
     contactEmail: metadata.contact.email,
   };
-  // if (metadata.graphic.slugs.wild && metadata.graphic.slugs.wild !== '') {
-  //   packMetadata.wildSlug = metadata.graphic.slugs.wild;
-  // }
 
-  await SERVER_CLIENT.updateGraphic(packMetadata);
-  const pack = SERVER_CLIENT?.graphic?.id;
+  await serverClient.updateGraphic(packMetadata);
   const { homepage: url } = getPkg();
   if (!url) {
     throw new PackageMetadataError(
@@ -34,5 +30,5 @@ export default async (metadata: PackMetadataType, config: ConfigType) => {
     );
   }
 
-  return { pack, url } as { pack: string; url: string };
+  return serverClient;
 };

--- a/src/publish/index.ts
+++ b/src/publish/index.ts
@@ -5,7 +5,6 @@ import type { PromptObject } from 'prompts';
 import chalk from 'chalk';
 import getPackMetadata from '../prepack/getPackMetadata';
 import getPkg from '../utils/getPkg';
-import getServerClient from '../utils/getServerClient';
 import prompts from 'prompts';
 import updateGraphicPack from '../prepack/updateGraphicPack';
 
@@ -17,8 +16,6 @@ export default async (config: ConfigType) => {
     return;
   }
 
-  const SERVER_CLIENT = getServerClient();
-
   if (process.env.GRAPHICS_SERVER_PUBLISH) {
     const MEDIA = process.env.GRAPHICS_SERVER_PUBLISH_TO_MEDIA
       ? ['media-interactive', 'EPS']
@@ -28,9 +25,9 @@ export default async (config: ConfigType) => {
       : false;
 
     const packMetadata = await getPackMetadata(config);
-    await updateGraphicPack(packMetadata, config);
+    const serverClient = await updateGraphicPack(packMetadata, config);
 
-    await SERVER_CLIENT.publishGraphic([], MEDIA, LYNX, false);
+    await serverClient.publishGraphic([], MEDIA, LYNX, false);
   } else {
     const questions = [
       {
@@ -62,9 +59,9 @@ export default async (config: ConfigType) => {
     const LYNX = publishToLynx ? ['interactive', 'JPG'] : false;
 
     const packMetadata = await getPackMetadata(config);
-    await updateGraphicPack(packMetadata, config);
+    const serverClient = await updateGraphicPack(packMetadata, config);
 
-    await SERVER_CLIENT.publishGraphic([], MEDIA, LYNX, isCorrection);
+    await serverClient.publishGraphic([], MEDIA, LYNX, isCorrection);
   }
 
   console.log(chalk`\n\nPublished to: {green ${pkg.homepage}}\n`);

--- a/src/upload/index.ts
+++ b/src/upload/index.ts
@@ -16,9 +16,9 @@ export default async (config: ConfigType, opts = defaultOptions) => {
   const { fast: publishPublicOnly } = opts;
   const measureImages = new MeasureImages(config.IMAGES_DIR);
   await measureImages.measureImages(opts);
-  await prepack(config);
+  const serverClient = await prepack(config);
   await pack(config);
-  await uploadPublicEdition(config);
-  if (!publishPublicOnly) await uploadMediaEditions(config);
+  await uploadPublicEdition(config, serverClient);
+  if (!publishPublicOnly) await uploadMediaEditions(config, serverClient);
   console.log(chalk`\n\n🏁 {green Finished uploading pack.}\n`);
 };

--- a/src/upload/mediaEditions/index.ts
+++ b/src/upload/mediaEditions/index.ts
@@ -1,13 +1,13 @@
 import { findIndex, uniq } from 'lodash-es';
 
 import { ConfigType } from '../../setConfig';
+import type ServerClient from '@reuters-graphics/server-client';
 import { VALID_LOCALES } from '../../constants/locales';
 import askJSON from 'ask-json';
 import fs from 'fs-extra';
 import getPackMetadata from '../../prepack/getPackMetadata';
 import getPkg from '../../utils/getPkg';
 import getSchema from './getSchema';
-import getServerClient from '../../utils/getServerClient';
 import glob from 'glob';
 import path from 'path';
 import { pymCodeFromTemplate } from '../../constants/embedCodes';
@@ -54,10 +54,9 @@ const updateMediaEditionMetadata = (metadata: {
   );
 };
 
-export default async (config: ConfigType) => {
+export default async (config: ConfigType, serverClient: ServerClient) => {
   const { title, description } = await getPackMetadata(config);
   const { homepage } = getPkg();
-  const SERVER_CLIENT = getServerClient();
 
   const mediaArchives = glob.sync('media-*.zip', { cwd: config.PACK_DIR });
 
@@ -97,19 +96,19 @@ export default async (config: ConfigType) => {
     );
 
     const existingArchives = uniq(
-      SERVER_CLIENT?.graphic?.editions.map((e) => e.file.fileName)
+      serverClient?.graphic?.editions.map((e) => e.file.fileName)
     );
 
     const exists = existingArchives.includes(mediaArchive);
 
     if (exists) {
-      await SERVER_CLIENT.updateEditions(
+      await serverClient.updateEditions(
         mediaArchive,
         fileBuffer,
         editionMetadata
       );
     } else {
-      await SERVER_CLIENT.createEditions(
+      await serverClient.createEditions(
         mediaArchive,
         fileBuffer,
         editionMetadata

--- a/src/upload/publicEdition/index.ts
+++ b/src/upload/publicEdition/index.ts
@@ -1,12 +1,11 @@
 import { ConfigType } from '../../setConfig';
+import type ServerClient from '@reuters-graphics/server-client';
 import fs from 'fs-extra';
 import getPackMetadata from '../../prepack/getPackMetadata';
-import getServerClient from '../../utils/getServerClient';
 import path from 'path';
 
-export default async (config: ConfigType) => {
+export default async (config: ConfigType, serverClient: ServerClient) => {
   const { title, description } = await getPackMetadata(config);
-  const SERVER_CLIENT = getServerClient();
 
   const editionMetadata = {
     language: config.PACK_LOCALE,
@@ -16,5 +15,5 @@ export default async (config: ConfigType) => {
 
   const fileBuffer = fs.readFileSync(path.join(config.PACK_DIR, 'public.zip'));
 
-  await SERVER_CLIENT.updateEditions('public.zip', fileBuffer, editionMetadata);
+  await serverClient.updateEditions('public.zip', fileBuffer, editionMetadata);
 };


### PR DESCRIPTION
Closes #59. Shares the server client across some methods that previously expected inherited properties to be set on it in early methods in the upload/publish chain.