### PR TITLE
Decrease zip archive compression level to boost speed

### DIFF
--- a/src/pack/edition/utils/archive.ts
+++ b/src/pack/edition/utils/archive.ts
@@ -57,7 +57,7 @@ class SrcArchive {
     }).filter(gitignoreFilter);
 
     const output = fs.createWriteStream(this.archivePath);
-    const archive = archiver('zip', { zlib: { level: 9 } });
+    const archive = archiver('zip', { zlib: { level: 6 } });
 
     await new Promise<void>((resolve, reject) => {
       output.on('close', () => {


### PR DESCRIPTION
Changed compression level from 9 to 6, which is the zlib default and should work faster.