### PR TITLE
Concurrent packUp and copyFile action

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "open": "^10.1.0",
     "open-graph-scraper": "^6.9.0",
     "ordinal": "^1.0.3",
+    "p-limit": "^7.3.0",
     "package-manager-detector": "^0.2.9",
     "parse5": "^8.0.0",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       ordinal:
         specifier: ^1.0.3
         version: 1.0.3
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
       package-manager-detector:
         specifier: ^0.2.9
         version: 0.2.9
@@ -4492,6 +4495,10 @@ packages:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
 
+  p-limit@7.3.0:
+    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
+    engines: {node: '>=20'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -5896,6 +5903,10 @@ packages:
 
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
+    engines: {node: '>=12.20'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
   yocto-spinner@0.2.1:
@@ -11550,6 +11561,10 @@ snapshots:
     dependencies:
       yocto-queue: 1.1.1
 
+  p-limit@7.3.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -13035,6 +13050,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
+
+  yocto-queue@1.2.2: {}
 
   yocto-spinner@0.2.1:
     dependencies:

--- a/src/pack/archive/index.ts
+++ b/src/pack/archive/index.ts
@@ -82,9 +82,9 @@ export class Archive {
     );
     if (!fs.existsSync(archiveDir))
       fs.mkdirSync(archiveDir, { recursive: true });
-    for (const edition of this.editions) {
-      await edition.packUp(archiveDir);
-    }
+    await Promise.all(
+      this.editions.map((edition) => edition.packUp(archiveDir))
+    );
     return zipDir(archiveDir);
   }
 

--- a/src/pack/edition/types/interactive.ts
+++ b/src/pack/edition/types/interactive.ts
@@ -116,10 +116,10 @@ export class Interactive extends Edition {
   async packUp(archiveDir: string) {
     const cwd = path.dirname(this.path);
     const files = globSync('**/*', { cwd, nodir: true });
-    
+
     // Limit concurrent file operations to 10
     const limit = pLimit(10);
-    
+
     await Promise.all(
       files.map((file) =>
         limit(async () => {
@@ -143,7 +143,7 @@ export class Interactive extends Edition {
         })
       )
     );
-    
+
     await this.makePreviewImage(archiveDir);
     if (this.archive.type === 'media') await this.makeManifest(archiveDir);
   }

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -123,9 +123,7 @@ export class Pack {
     const s = spinner(2000);
     s.start('Packing up graphic pack');
     utils.fs.ensureDir(this.packRoot);
-    for (const archive of this.archives) {
-      await archive.packUp();
-    }
+    await Promise.all(this.archives.map(archive => archive.packUp()));
     await s.stop('📦 All packed.');
   }
 

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -123,7 +123,7 @@ export class Pack {
     const s = spinner(2000);
     s.start('Packing up graphic pack');
     utils.fs.ensureDir(this.packRoot);
-    await Promise.all(this.archives.map(archive => archive.packUp()));
+    await Promise.all(this.archives.map((archive) => archive.packUp()));
     await s.stop('📦 All packed.');
   }
 


### PR DESCRIPTION
This is intended to improve performance and speed things up by pooling some file operations.

The `p-limit` library is added to limiting concurrent operations and avoid overwhelming the system.