### PR TITLE
Optimize build process by skipping rebuild on subsequent uploads

### DIFF
--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -108,10 +108,20 @@ export class Pack {
     const finder = new Finder(this);
     finder.findEditions(publicOnly);
     finder.logFound();
+
+    // Check if we already have a homepage URL before getMetadata
+    const hadHomepage = !!PKG.homepage;
+
     for (const archive of this.archives) {
       await archive.getMetadata();
     }
-    await buildForProduction();
+
+    // Only rebuild if we didn't have a URL before (first upload)
+    // On subsequent uploads, PKG.homepage is already set, so no rebuild needed
+    if (!hadHomepage && PKG.homepage) {
+      await buildForProduction();
+    }
+
     await this.packUp();
     for (const archive of this.archives) {
       await archive.createOrUpdate();


### PR DESCRIPTION
Am I right to surmise that the reason we build the production files twice is to get the homepage URL created on the first upload?

If that's right, could we save time by inly triggering `buildForProduction()` on first upload when homepage URL is initially fetched via `getMetadata()`?

If I have a misconception here, which I likely do, please school me.