### PR TITLE
chore: default workflows to node 22 and bump action versions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,4 +9,4 @@ jobs:
     secrets: inherit
     with:
       docs_directory: './dist'
-      node_version: '20'
+      node_version: '22'

--- a/.github/workflows/pkg.pr.new.yaml
+++ b/.github/workflows/pkg.pr.new.yaml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: reuters-graphics/action-workflows/.github/workflows/changesets-release.yaml@main
     secrets: inherit
     with:
-      node_version: '20'
+      node_version: '22'
       publish_docs: true
       docs_directory: './dist'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
     uses: reuters-graphics/action-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:
-      node_versions: '[18,20,22]'
+      node_versions: '[20,22]'


### PR DESCRIPTION
## Summary

Updates the minimum Node version across GitHub workflows and refreshes action dependencies.

- **Default Node → 22** in `docs.yaml`, `release.yaml`, and `pkg.pr.new.yaml`
- **Test matrix → `[20, 22]`** (drops EOL Node 18)
- **Action bumps** in `pkg.pr.new.yaml` (verified latest via `git ls-remote`):
  - `actions/checkout` v4 → v7
  - `pnpm/action-setup` v4 → v6
  - `actions/setup-node` v4 → v6

## Node 24 deferred

Node 24 was originally included in the matrix but surfaced pre-existing test-isolation bugs (import-time `context` singleton side-effect + `mock-fs` ordering). Rather than expand this workflows chore, Node 24 is left out of the matrix for now and tracked in #133.

## Notes

- `lint.yaml` has no Node input or inline actions — unchanged.
- `peter-evans/repository-dispatch@v4` is already the latest major — unchanged.
- The reusable workflows delegate to `reuters-graphics/action-workflows@main`, so their internal action versions live in that repo; only the Node inputs are set here.
- No changeset — no library code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)