### PR TITLE
feat: ship LLM context docs with the package

### DIFF
--- a/.changeset/llm-context-docs.md
+++ b/.changeset/llm-context-docs.md
@@ -1,0 +1,7 @@
+---
+'@reuters-graphics/graphics-kit-publisher': minor
+---
+
+Ships LLM context docs with the package for consuming projects' coding agents. Adds an `llms/` folder of terse, agent-oriented reference docs (graphics server model, pack metadata, page-building/routing rules, config, and a glossary) and declares them under a new `llms` field in `package.json` so downstream tooling can hoist them into a project's `.claude/llms/`. Also adds a human-facing docs page explaining the docs exist and that library developers may need to update them.
+
+Fixes an incorrect validation message on the pack `title` max-length rule (it referenced "Description").

--- a/docs/content/docs/llm-docs.mdx
+++ b/docs/content/docs/llm-docs.mdx
@@ -1,0 +1,61 @@
+---
+title: LLM context docs
+sidebar:
+  order: 40
+---
+
+import { Aside, FileTree } from '@astrojs/starlight/components';
+
+This package ships a set of documentation written specifically for **large language models** — the coding agents developers use to build graphics projects.
+
+These are separate from the docs you're reading now. The docs on this site are for humans; the LLM docs are terse, structured reference files designed to give an agent accurate context about how the publisher, pack metadata, routing rules and the graphics server work.
+
+## Where they live
+
+The LLM docs are markdown files in the [`llms/`](https://github.com/reuters-graphics/graphics-kit-publisher/tree/main/llms) folder of this package, and they're published to npm as part of it.
+
+<FileTree>
+- llms
+  - index.md Root doc — links to the others
+  - graphics-server.md
+  - pack-metadata.md
+  - page-building.md
+  - config.md
+  - glossary.md
+</FileTree>
+
+The package declares them under an `llms` key in its `package.json`:
+
+```jsonc
+// package.json
+{
+  "files": ["dist/**/*", "llms/**/*"], // published to npm
+  "llms": {
+    "description": ["A filesystem-based publisher for Reuters Graphics projects.", "..."],
+    "files": ["./llms/**/*"]
+  }
+}
+```
+
+## How they're used
+
+Because the docs ship with the package, they're present in the consuming project's `node_modules`. Tooling in the [graphics kit](https://github.com/reuters-graphics/bluprint_graphics-kit) reads the `llms` field, copies the docs into the project's `.claude/llms/` directory, and links them from the project's agent instructions. `index.md` is the entry point; it points to the other docs so an agent can pull just the context it needs, on demand.
+
+## For developers of this library
+
+<Aside type="caution">
+  When you change the publisher's behavior, the LLM docs may need updating too —
+  not just this site.
+</Aside>
+
+The `llms/` docs describe the same system these human docs do, so they can drift out of date the same way. When you make a change that affects how the publisher behaves, check whether the relevant LLM doc needs to change as well:
+
+- **Routing / build rules, `packLocations`, build logs** (`.graphics-kit/logs/`, `src/logging`, `src/build`) → `llms/page-building.md`
+- **Pack metadata, the `reuters` key, `PKG` getters, metadata pointers** → `llms/pack-metadata.md`
+- **Metadata validation rules** in `src/validators/pack.ts` (slug patterns, field lengths, allowed `desk`/`language`, email domain) and `src/pack/archive/metadata.ts` (the shared 255-char title/description budget) → `llms/pack-metadata.md`
+- **Graphics server model** (packs, archives, editions, publishing locations) → `llms/graphics-server.md`
+- **Config options** → `llms/config.md`
+- **New or renamed terms** → `llms/glossary.md`
+- **Overview, workflow, or the set of docs itself** → `llms/index.md`
+
+Keep them **succinct and factual** — they're context for a model, not a tutorial. Prefer rules, constraints and naming conventions over prose, and cross-link between the docs rather than repeating detail.

--- a/llms/config.md
+++ b/llms/config.md
@@ -115,7 +115,7 @@ Rules for where archives are allowed to publish. An array; each entry matches ar
 publishingLocations: [
   { archive: 'public', availableLocations: { lynx: false, connect: false } },
   { archive: /-referral$/, availableLocations: { lynx: true, connect: false } },
-]
+];
 ```
 
 - **archive** — a `string` or `RegExp` matching an [archive ID](./graphics-server.md#archive-naming).

--- a/llms/config.md
+++ b/llms/config.md
@@ -1,0 +1,123 @@
+---
+name: Configuration
+description: Reference for publisher.config.ts options — build, packLocations, metadataPointers, archiveEditions, embedTemplate, and publishingLocations.
+---
+
+# Configuration
+
+The publisher is configured with `publisher.config.ts` in the project root. All options are optional and have sensible defaults.
+
+```typescript
+// publisher.config.ts
+import { defineConfig } from '@reuters-graphics/graphics-kit-publisher';
+
+export default defineConfig({
+  // options below
+});
+```
+
+Options are grouped into six keys: `build`, `packLocations`, `metadataPointers`, `archiveEditions`, `embedTemplate`, `publishingLocations`. `packLocations` and `metadataPointers` are covered in depth in [page-building.md](./page-building.md) and [pack-metadata.md](./pack-metadata.md) respectively and summarized here.
+
+## build
+
+Controls how the publisher builds and reads the project.
+
+```typescript
+build: {
+  scripts: { preview: 'build:preview', production: 'build' }, // npm script keys
+  outDir: 'dist/',                                            // where the build writes output
+}
+```
+
+- **build.scripts** — the `package.json` npm script keys the publisher runs for the `preview` and `production` builds. Defaults `{ preview: 'build:preview', production: 'build' }`.
+- **build.outDir** — the directory the build system writes to. Default `'dist/'`.
+
+## packLocations
+
+Maps built files to [editions](./graphics-server.md#editions). Each may be `false` if the project has none of that type. See [page-building.md](./page-building.md#packlocations-mapping-built-files--editions) for capture-group details.
+
+```typescript
+packLocations: {
+  dotcom: 'dist/',                          // string | false — the `public` archive; needs root index.html
+  embeds: 'dist/embeds/{locale}/{slug}/',   // string | false — media-* interactive editions; needs root index.html
+  statics: 'media-assets/{locale}/{slug}/', // string | false — static/editable editions; needs a root static file
+}
+```
+
+- **dotcom** (default `'dist/'`) — directory of reuters.com page(s). Must contain a root `index.html`.
+- **embeds** (default `'dist/embeds/{locale}/{slug}/'`) — pattern capturing every embeddable page directory. Must include `{locale}` and `{slug}` capture groups; each directory needs a root `index.html`.
+- **statics** (default `'media-assets/{locale}/{slug}/'`) — pattern capturing directories of static graphics. Must include `{locale}` and `{slug}`; each needs at least one root static file (`.eps`, `.jpg`, `.png`, `.pdf`).
+
+## metadataPointers
+
+Tells the publisher where to source metadata values from project files (JSON or built HTML). Full syntax, defaults and the pointer object (`path`, `format`, `validate`, `promptAsInitial`) are in [pack-metadata.md](./pack-metadata.md#sourcing-metadata-pointers).
+
+```typescript
+metadataPointers: {
+  pack: {
+    rootSlug: 'locales/en/content.json?story.rootSlug',
+    wildSlug: 'locales/en/content.json?story.wildSlug',
+    desk: { path: '~/.reuters-graphics/profile.json?desk', promptAsInitial: true },
+    language: 'en',                    // bare string = literal RNGS language code, not a pointer
+    title: 'dist/index.html?title',
+    byline: 'locales/en/content.json?story.authors',
+    contactEmail: '~/.reuters-graphics/profile.json?email',
+  },
+  edition: {
+    title: 'index.html?title',                    // path is relative to the edition root
+    description: 'index.html?meta.og:description',
+  },
+}
+```
+
+## archiveEditions
+
+Controls the source archives shared with clients on Reuters Connect.
+
+```typescript
+archiveEditions: {
+  docs: {                              // files created in the root of media-interactive editions
+    'README.txt': 'src/docs/readme.txt',        // REQUIRED — the media-interactive root file
+    'EMBED.html': 'src/docs/embed.html',
+  },
+  ignore: ['project-files/'],          // extra gitignore-style patterns to exclude from the client source zip
+  separateAssets: 'project-files/',    // string | false — dir uploaded to S3 separately (default 'project-files/')
+}
+```
+
+- **docs** — `Record<string, string | function>`. Each key is a filename created at the root of every `media-interactive` edition. You **must** define a `README.txt` key (it becomes the edition's [root file](./graphics-server.md#editions)).
+  - **string value** — a path to a local file, copied in and rendered as a [mustache](https://github.com/janl/mustache.js) template with context `{ embedUrl, embedSlug, year }`.
+  - **function value** — `(args: { embedUrl, embedSlug }) => string` returning the file contents.
+- **ignore** — `string[]` of [gitignore-pattern](https://git-scm.com/docs/gitignore#_pattern_format) globs to exclude from the client source ZIP, in addition to the project's `.gitignore`. Default `[]`.
+- **separateAssets** — a directory whose contents are zipped and uploaded to S3 separately (useful for large precursor files like Illustrator/Photoshop that clients may need). The link is saved to `reuters.separateAssets`. Default `'project-files/'`; set `false` to disable.
+
+## embedTemplate
+
+The embed code emitted for published embeddable graphics.
+
+```typescript
+embedTemplate: {
+  declaration: ({ embedUrl, embedSlug }) =>
+    `<div id="${embedSlug}"></div><script type="text/javascript">new pym.Parent("${embedSlug}", "${embedUrl}", {});</script>`,
+  dependencies: ({ embedUrl, embedSlug }) =>
+    `<script type="text/javascript" src="//graphics.thomsonreuters.com/pym.min.js"></script>`,
+}
+```
+
+- **declaration** — `({ embedUrl, embedSlug }) => string`. The embed markup for a single graphic.
+- **dependencies** — `({ embedUrl, embedSlug }) => string`. Scripts included once per page (usually in `<head>`).
+
+## publishingLocations
+
+Rules for where archives are allowed to publish. An array; each entry matches archive IDs and sets allowed locations. Default `[]`.
+
+```typescript
+publishingLocations: [
+  { archive: 'public', availableLocations: { lynx: false, connect: false } },
+  { archive: /-referral$/, availableLocations: { lynx: true, connect: false } },
+]
+```
+
+- **archive** — a `string` or `RegExp` matching an [archive ID](./graphics-server.md#archive-naming).
+- **availableLocations.lynx** — whether matching archives may be promoted/searchable in [Lynx](./glossary.md#publishing-destinations).
+- **availableLocations.connect** — whether matching archives may publish to [Reuters Connect](./glossary.md#publishing-destinations).

--- a/llms/glossary.md
+++ b/llms/glossary.md
@@ -1,0 +1,72 @@
+---
+name: Glossary
+description: Key terms for the graphics kit publisher and the Sphinx graphics server — pack, archive, edition, slug, desk, RNGS, Lynx, Connect, and related concepts.
+---
+
+# Glossary
+
+## Graphics server structure
+
+**Sphinx graphics server** — Reuters' server that stores and publishes graphics. The publisher uploads to it. Defines the pack/archive/edition structure everything conforms to.
+
+**Graphic pack** — The top-level unit: an entire graphics project, containing one or more archives. Identified in the server by a UUID (`reuters.graphic.pack` in `package.json`).
+
+**Archive** — A ZIP uploaded to the server, representing one graphic or a set of HTML pages. Contains one or more editions; must contain at least one. Named `public.zip` or `media-{locale}-{slug}.zip`. Referenced locally by its **archive ID** (e.g. `public`, `media-en-map`).
+
+**Edition** — A single _format_ of a graphic inside an archive (a folder locally). Its **root file** sets its format and available publishing options. See edition types below.
+
+**Root file** — The file at an edition folder's top level that defines its format. `.html` takes precedence; also `.txt`, `.jpg`, `.png`, `.pdf`. With multiple same-type files, the first zipped wins (order not controllable) — so keep one clear root file.
+
+## Edition types
+
+**Interactive edition** — HTML page(s) for reuters.com. Root file `index.html`. Needs a preview image. Publishes to Public RNGS; may be searchable in Lynx.
+
+**Media-interactive edition** — An embeddable graphic (a zipped copy of the project, `app.zip`) for Reuters Connect / Lynx / Arc. Root file `README.txt`. Needs a preview image.
+
+**Static file edition** — A single static image (`JPG`/`PNG`) or editable source (`EPS`/`PDF`). Root file matches the edition type (e.g. the `PNG` edition → `map.png`). JPG/PNG publish to Public RNGS; EPS/PDF to Reuters Connect.
+
+## Identifiers
+
+**Slug** — An ID for a graphic within an archive (`map`, `bar-chart`, `page`).
+
+**Root slug** — The project-level slug identifying the whole pack (`reuters.graphic.slugs.root`); appears in URLs. Follows a strict uppercase, hyphenated server pattern (e.g. `HEALTH-CORONAVIRUS`) — ask the user for it rather than generating one. See [pack-metadata.md](./pack-metadata.md#slugs-ask-the-user-dont-generate-them).
+
+**Wild slug** — A secondary, "wild" slug segment for the pack (`reuters.graphic.slugs.wild`); appears in URLs alongside the root slug. Follows a strict server pattern (e.g. `MAP`) and may be empty — ask the user for it. See [pack-metadata.md](./pack-metadata.md#slugs-ask-the-user-dont-generate-them).
+
+**Locale / language** — A valid RNGS language code identifying an archive/edition's or pack's language. One of `en`, `ar`, `fr`, `es`, `de`, `it`, `ja`, `pt`, `ru` (usually `en`).
+
+**Desk** — The Reuters graphics desk owning the pack, typically sourced from the user's local profile. One of `london`, `new york`, `singapore`, `bengaluru`.
+
+## Publishing destinations
+
+**RNGS** — Reuters News Graphics Service. **Public RNGS** is the public destination on reuters.com for interactive and JPG/PNG editions.
+
+**Reuters Connect** — The platform where media clients purchase/embed graphics. Destination for media-interactive and EPS/PDF editions. Also called "Media" as a publishing location.
+
+**Lynx** — Reuters' story editor. An edition "searchable in Lynx" can be embedded into other reuters.com stories (via Lynx/Arc embed tools). Only interactive editions should be searchable; the publisher sets this automatically when publishing from the terminal.
+
+**Arc** — A publishing/editor system that can embed Lynx-searchable graphics into stories.
+
+## Publisher concepts
+
+**publisher.config.ts** — The project's config file, created with `defineConfig`.
+
+**packLocations** — Config mapping built files to editions: `dotcom` (the `public` archive), `embeds` (`media-*` interactive editions), `statics` (static/editable editions). Embed/static patterns use `{locale}` and `{slug}` capture groups.
+
+**Metadata pointer** — A config entry telling the publisher where to read a metadata value from a project file, written as `"<file path>?<data path>"` (e.g. `locales/en/content.json?story.title`), optionally with `format`, `validate`, and `promptAsInitial`.
+
+**Pack metadata** — Data saved to `package.json` under the `reuters` key (pack ID, slugs, desk, authors, timestamps, archives/editions and their URLs). Read it with the **`PKG`** getters.
+
+**PKG** — The exported module of typed getters for pack metadata (`PKG.homepage`, `PKG.pack.rootSlug`, `PKG.archive(id).url`, …).
+
+**getBasePath** — Exported utility returning the base/asset path for a build `mode` (`dev`/`test`/`preview`/`prod`) from URLs saved in `package.json`.
+
+**Separate assets** — A directory (e.g. precursor Illustrator/Photoshop files) uploaded as a single ZIP to S3 rather than the graphics server, with its link saved to `reuters.separateAssets`. Configured via `archiveEditions.separateAssets`.
+
+**Preview image** — An image representing an edition in the graphics server, Lynx and Connect: an `og:image` tag or a `_gfxpreview.png`/`.jpg` at the edition root.
+
+**Two-pass build** — The publisher builds a project twice on upload: first without base-path URLs (to detect archives), then a production build using the server-issued URLs it obtained in between.
+
+**Preview** — A build uploaded to the testfiles S3 bucket for review, before creating a real graphics-server pack (`graphics-publisher preview`).
+
+**`.graphics-kit/`** — A working directory the publisher manages in the project root (build logs, packing, temp files); excluded from packed archives. Its `logs/` holds `error.log` (build `stderr`) and `out.log` (build `stdout`), overwritten and timestamped each build — read `error.log` to diagnose a failed `preview`/`upload` build.

--- a/llms/graphics-server.md
+++ b/llms/graphics-server.md
@@ -32,6 +32,7 @@ Archives are named by convention:
 - `media-{locale}-{slug}.zip` — a media/client archive.
 
 Where:
+
 - **locale** is a valid RNGS language code (`en`, `de`, `es`, …).
 - **slug** identifies the graphic (`map`, `bar-chart`, `page`, …).
 
@@ -41,13 +42,14 @@ Each edition is a folder containing a **root file** at its top level. The root f
 
 ### Edition types
 
-| Edition | Root file | Contains | Represents |
-|---|---|---|---|
-| **interactive** | `index.html` | HTML page(s) + assets | A page published on reuters.com |
-| **media-interactive** | `README.txt` | a zipped copy of the project (`app.zip`) | An embeddable graphic purchasable/embeddable via Connect, Lynx or Arc |
-| **static** (`JPG`/`PNG`/`EPS`/`PDF`) | file matching the edition name (e.g. `map.png`) | one static/editable file | A static image (JPG/PNG) or editable source (EPS/PDF) |
+| Edition                              | Root file                                       | Contains                                 | Represents                                                            |
+| ------------------------------------ | ----------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------- |
+| **interactive**                      | `index.html`                                    | HTML page(s) + assets                    | A page published on reuters.com                                       |
+| **media-interactive**                | `README.txt`                                    | a zipped copy of the project (`app.zip`) | An embeddable graphic purchasable/embeddable via Connect, Lynx or Arc |
+| **static** (`JPG`/`PNG`/`EPS`/`PDF`) | file matching the edition name (e.g. `map.png`) | one static/editable file                 | A static image (JPG/PNG) or editable source (EPS/PDF)                 |
 
 Notes:
+
 - **interactive**: additional HTML pages should be at least one directory below the root `index.html`; CSS/JS/images may sit alongside it. Requires a preview image at the edition root (`_gfxpreview.png`/`.jpg`) or an `og:image` in the page.
 - **media-interactive**: also requires a preview image at the edition root.
 - **static**: the root file can be named anything but should match the edition's type (e.g. the `PNG` edition's root is a `.png`). An edition folder may hold companion files (e.g. an `EPS` edition containing both `my-map.eps` and a `map.jpg`).
@@ -62,11 +64,11 @@ Editions ultimately reach readers on reuters.com or media clients on Reuters Con
 
 Summary of routing:
 
-| Edition | Public RNGS | Reuters Connect | Lynx searchable |
-|---|---|---|---|
-| interactive | ✅ | — | ✅ (interactive only) |
-| media-interactive | — | ✅ | — |
-| JPG / PNG (static) | ✅ | — | — |
-| EPS / PDF (static) | — | ✅ | — |
+| Edition            | Public RNGS | Reuters Connect | Lynx searchable       |
+| ------------------ | ----------- | --------------- | --------------------- |
+| interactive        | ✅          | —               | ✅ (interactive only) |
+| media-interactive  | —           | ✅              | —                     |
+| JPG / PNG (static) | ✅          | —               | —                     |
+| EPS / PDF (static) | —           | ✅              | —                     |
 
 Publishing options are set per edition and determine if and where a graphic actually publishes. See [pack-metadata.md](./pack-metadata.md) for how archive/edition state is recorded, and [page-building.md](./page-building.md) for how local built files map to these editions.

--- a/llms/graphics-server.md
+++ b/llms/graphics-server.md
@@ -1,0 +1,72 @@
+---
+name: Graphics server (Sphinx)
+description: How the Sphinx graphics server represents projects — graphic packs, archives, editions, root files, edition types, and publishing locations.
+---
+
+# Graphics server (Sphinx)
+
+The publisher uploads projects to Reuters' **Sphinx graphics server**. Everything the publisher does is in service of producing the structure Sphinx expects. That structure has three nested levels:
+
+- **Graphic pack** — the overall project. Contains one or more archives.
+- **Archive** — a ZIP uploaded to the server. Represents a single graphic or a set of HTML pages. Contains one or more editions. Must contain at least one edition.
+- **Edition** — a specific _format_ of a graphic (an interactive page, an embeddable app, a static image, an editable file).
+
+```
+graphic pack
+├── public.zip                 ← archive
+│   └── interactive            ← edition
+├── media-en-map.zip           ← archive
+│   ├── interactive            ← edition
+│   ├── media-interactive      ← edition
+│   ├── PNG                    ← edition
+│   └── EPS                    ← edition
+```
+
+On the local filesystem, an archive is a folder containing one or more edition folders. The publisher zips each archive folder before upload.
+
+## Archive naming
+
+Archives are named by convention:
+
+- `public.zip` — the reuters.com page(s).
+- `media-{locale}-{slug}.zip` — a media/client archive.
+
+Where:
+- **locale** is a valid RNGS language code (`en`, `de`, `es`, …).
+- **slug** identifies the graphic (`map`, `bar-chart`, `page`, …).
+
+## Editions
+
+Each edition is a folder containing a **root file** at its top level. The root file's type determines the edition's format and which publishing options the server offers. `.html` takes precedence when present; other root types: `.txt`, `.jpg`, `.png`, `.pdf`. If multiple files of the same type sit at the root, the first added to the zip wins — and the add order **cannot** currently be controlled, so keep a single unambiguous root file.
+
+### Edition types
+
+| Edition | Root file | Contains | Represents |
+|---|---|---|---|
+| **interactive** | `index.html` | HTML page(s) + assets | A page published on reuters.com |
+| **media-interactive** | `README.txt` | a zipped copy of the project (`app.zip`) | An embeddable graphic purchasable/embeddable via Connect, Lynx or Arc |
+| **static** (`JPG`/`PNG`/`EPS`/`PDF`) | file matching the edition name (e.g. `map.png`) | one static/editable file | A static image (JPG/PNG) or editable source (EPS/PDF) |
+
+Notes:
+- **interactive**: additional HTML pages should be at least one directory below the root `index.html`; CSS/JS/images may sit alongside it. Requires a preview image at the edition root (`_gfxpreview.png`/`.jpg`) or an `og:image` in the page.
+- **media-interactive**: also requires a preview image at the edition root.
+- **static**: the root file can be named anything but should match the edition's type (e.g. the `PNG` edition's root is a `.png`). An edition folder may hold companion files (e.g. an `EPS` edition containing both `my-map.eps` and a `map.jpg`).
+
+## Where editions publish
+
+Editions ultimately reach readers on reuters.com or media clients on Reuters Connect. Two publishing "locations" gate this, plus a searchability flag:
+
+- **Public RNGS** — a public URL on reuters.com. Available only to **interactive** editions and **JPG/PNG** static editions.
+- **Media (Reuters Connect)** — a purchasable graphic on Connect. Available only to **media-interactive** editions and **EPS/PDF** static editions.
+- **Searchable in Lynx** — makes an edition embeddable in other reuters.com stories via Lynx/Arc embed tools. Only **interactive** editions should be made searchable. The publisher sets this automatically when publishing from the terminal.
+
+Summary of routing:
+
+| Edition | Public RNGS | Reuters Connect | Lynx searchable |
+|---|---|---|---|
+| interactive | ✅ | — | ✅ (interactive only) |
+| media-interactive | — | ✅ | — |
+| JPG / PNG (static) | ✅ | — | — |
+| EPS / PDF (static) | — | ✅ | — |
+
+Publishing options are set per edition and determine if and where a graphic actually publishes. See [pack-metadata.md](./pack-metadata.md) for how archive/edition state is recorded, and [page-building.md](./page-building.md) for how local built files map to these editions.

--- a/llms/index.md
+++ b/llms/index.md
@@ -13,13 +13,13 @@ It makes few assumptions about how a project is built, so it works with any page
 
 Read these on demand — pull the one relevant to the task rather than loading all of them.
 
-| Doc | When to use |
-|---|---|
-| [`graphics-server.md`](./graphics-server.md) | Understanding how the Sphinx graphics server represents projects: graphic packs, archives, editions, root files, edition types, and where each publishes (RNGS / Lynx / Connect). |
-| [`pack-metadata.md`](./pack-metadata.md) | Working with pack metadata in `package.json` (the `reuters` key), the `PKG` getters, or metadata pointers — including **pre-filling the metadata Sphinx requires** so a CLI upload won't stall on prompts, and which server-written fields must **never** be hand-edited. |
-| [`page-building.md`](./page-building.md) | Routing/build rules the publisher enforces: directory-based pages, canonical links, base paths, the two-pass production build, preview images, and `packLocations` config. |
-| [`config.md`](./config.md) | Reference for all `publisher.config.ts` options: `build`, `packLocations`, `metadataPointers`, `archiveEditions`, `embedTemplate`, `publishingLocations`. |
-| [`glossary.md`](./glossary.md) | Definitions of key terms, especially graphics-server concepts (pack, archive, edition, slug, desk, RNGS, Lynx, Connect). |
+| Doc                                          | When to use                                                                                                                                                                                                                                                               |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`graphics-server.md`](./graphics-server.md) | Understanding how the Sphinx graphics server represents projects: graphic packs, archives, editions, root files, edition types, and where each publishes (RNGS / Lynx / Connect).                                                                                         |
+| [`pack-metadata.md`](./pack-metadata.md)     | Working with pack metadata in `package.json` (the `reuters` key), the `PKG` getters, or metadata pointers — including **pre-filling the metadata Sphinx requires** so a CLI upload won't stall on prompts, and which server-written fields must **never** be hand-edited. |
+| [`page-building.md`](./page-building.md)     | Routing/build rules the publisher enforces: directory-based pages, canonical links, base paths, the two-pass production build, preview images, and `packLocations` config.                                                                                                |
+| [`config.md`](./config.md)                   | Reference for all `publisher.config.ts` options: `build`, `packLocations`, `metadataPointers`, `archiveEditions`, `embedTemplate`, `publishingLocations`.                                                                                                                 |
+| [`glossary.md`](./glossary.md)               | Definitions of key terms, especially graphics-server concepts (pack, archive, edition, slug, desk, RNGS, Lynx, Connect).                                                                                                                                                  |
 
 ## Setup
 

--- a/llms/index.md
+++ b/llms/index.md
@@ -1,0 +1,51 @@
+---
+name: '@reuters-graphics/graphics-kit-publisher'
+description: Publishing Reuters Graphics projects to the Sphinx graphics server — packing built files into archives/editions, pack metadata, routing rules, and the graphics server model.
+---
+
+# Graphics kit publisher
+
+A filesystem-based publisher for Reuters Graphics projects. It takes a project's **built files** — dotcom pages, embeddable pages and static graphics — matches them to a filesystem pattern, packs them into the archive/edition structure the **Sphinx graphics server** expects, and uploads them for publishing to [reuters.com](https://www.reuters.com/graphics/) and to media clients via [Reuters Connect](https://www.reutersconnect.com/).
+
+It makes few assumptions about how a project is built, so it works with any page builder that outputs a predictable pattern of files (a good fit for filesystem-routed frameworks like SvelteKit and Next.js).
+
+## When to read which doc
+
+Read these on demand — pull the one relevant to the task rather than loading all of them.
+
+| Doc | When to use |
+|---|---|
+| [`graphics-server.md`](./graphics-server.md) | Understanding how the Sphinx graphics server represents projects: graphic packs, archives, editions, root files, edition types, and where each publishes (RNGS / Lynx / Connect). |
+| [`pack-metadata.md`](./pack-metadata.md) | Working with pack metadata in `package.json` (the `reuters` key), the `PKG` getters, or metadata pointers — including **pre-filling the metadata Sphinx requires** so a CLI upload won't stall on prompts, and which server-written fields must **never** be hand-edited. |
+| [`page-building.md`](./page-building.md) | Routing/build rules the publisher enforces: directory-based pages, canonical links, base paths, the two-pass production build, preview images, and `packLocations` config. |
+| [`config.md`](./config.md) | Reference for all `publisher.config.ts` options: `build`, `packLocations`, `metadataPointers`, `archiveEditions`, `embedTemplate`, `publishingLocations`. |
+| [`glossary.md`](./glossary.md) | Definitions of key terms, especially graphics-server concepts (pack, archive, edition, slug, desk, RNGS, Lynx, Connect). |
+
+## Setup
+
+The publisher is configured with a `publisher.config.ts` in the project root:
+
+```typescript
+// publisher.config.ts
+import { defineConfig } from '@reuters-graphics/graphics-kit-publisher';
+
+export default defineConfig({
+  // Config options — all optional; sensible defaults apply.
+});
+```
+
+Config groups: `build` (build scripts + outDir), `packLocations` (where built files live), `metadataPointers` (where to source metadata), `archiveEditions` (client source archives + separate assets), `embedTemplate`, and `publishingLocations` (where archives may publish). See [config.md](./config.md) for the full option reference.
+
+## Workflow
+
+The publisher is driven by a CLI (`graphics-publisher`) with three main commands, normally run in order:
+
+1. `graphics-publisher preview` — Build and upload a preview to the testfiles S3 bucket (no graphics server pack created).
+2. `graphics-publisher upload` — Create/update the graphic pack in the graphics server and upload archives. `upload:quick` uploads only the `public` archive (the reuters.com page); run a full `upload` afterward to sync embeds and Connect editions.
+3. `graphics-publisher publish` — Publish the pack in the graphics server.
+
+`preview`, `upload` and `publish` all run the project's build scripts first; a failed build aborts the command. Build output is written to `.graphics-kit/logs/` (`error.log`, `out.log`) — **check `error.log` first** when a command fails at the build step. See [page-building.md](./page-building.md#build-logs--diagnosing-failures).
+
+Recovery commands: `restart` (clear pack IDs/URLs from `package.json` to create a fresh pack next upload, preserving other metadata) and `delete` (delete the pack in the server and clear its metadata — only possible if the pack has **not** yet published).
+
+Programmatic entry points are exported from the package root, including `defineConfig`, the `getBasePath` utility, and the `PKG` metadata module.

--- a/llms/pack-metadata.md
+++ b/llms/pack-metadata.md
@@ -17,34 +17,39 @@ After uploading, metadata is saved mostly under `reuters` (plus a top-level `hom
 ```jsonc
 {
   "reuters": {
-    "preview": "https://graphics.thomsonreuters.com/.../",       // preview URL
+    "preview": "https://graphics.thomsonreuters.com/.../", // preview URL
     "separateAssets": "https://graphics.thomsonreuters.com/.../assets.zip",
     "graphic": {
-      "pack": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",             // pack ID in Sphinx
+      "pack": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX", // pack ID in Sphinx
       "desk": "london",
       "slugs": { "root": "ROOT-SLUG", "wild": "WILD" },
       "contactEmail": "jane.doe@thomsonreuters.com",
       "title": "A title",
-      "description": "Graphic",                                    // defaults to "Graphic"
-      "authors": [{ "name": "Jane Doe", "link": "https://www.reuters.com/authors/jane-doe/" }],
-      "published": "2025-02-23T00:00:00.000Z",                     // first publish
-      "updated": "2025-02-24T00:00:00.000Z",                       // latest publish
+      "description": "Graphic", // defaults to "Graphic"
+      "authors": [
+        {
+          "name": "Jane Doe",
+          "link": "https://www.reuters.com/authors/jane-doe/",
+        },
+      ],
+      "published": "2025-02-23T00:00:00.000Z", // first publish
+      "updated": "2025-02-24T00:00:00.000Z", // latest publish
       "archives": {
         "public": {
           "url": "https://www.reuters.com/graphics/.../",
           "title": "A title",
           "description": "A description",
           "uploaded": "2025-02-24T00:00:00.000Z",
-          "editions": ["interactive"]
+          "editions": ["interactive"],
         },
         "media-en-page": {
           "url": "https://www.reuters.com/graphics/.../",
-          "editions": ["interactive", "media-interactive", "EPS", "JPG"]
-        }
-      }
-    }
+          "editions": ["interactive", "media-interactive", "EPS", "JPG"],
+        },
+      },
+    },
   },
-  "homepage": "https://www.reuters.com/graphics/.../"              // set if a `public` archive exists
+  "homepage": "https://www.reuters.com/graphics/.../", // set if a `public` archive exists
 }
 ```
 
@@ -58,23 +63,23 @@ These fields are **required by the Sphinx server** to upload a pack _and_ are hu
 
 Under `reuters.graphic`:
 
-| Field | Requirement |
-|---|---|
-| `desk` | One of `london`, `new york`, `singapore`, `bengaluru`. |
-| `slugs.root` | Strict server pattern; identifies the graphic in URLs. **Ask the user — do not invent one** (see below). |
-| `slugs.wild` | Strict server pattern; **may be `""`** (empty). **Ask the user** (see below). |
-| `language` | RNGS language code: one of `en`, `ar`, `fr`, `es`, `de`, `it`, `ja`, `pt`, `ru` (usually `en`). |
-| `title` | The graphic pack's title. Describes the specific topic the graphics pack covers, e.g., "Iran crisis blog". 3–150 characters. |
-| `description` | The graphic pack's description. Often kept as short as the string "Graphic:". 3–150 characters. |
-| `contactEmail` | A valid email ending in `@thomsonreuters.com`. |
-| `authors` | Array with **at least one** entry; each requires a `name` (≥3 chars) and a `link` (valid URL). (Sourced by the publisher from the `byline` pointer.) |
+| Field          | Requirement                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `desk`         | One of `london`, `new york`, `singapore`, `bengaluru`.                                                                                               |
+| `slugs.root`   | Strict server pattern; identifies the graphic in URLs. **Ask the user — do not invent one** (see below).                                             |
+| `slugs.wild`   | Strict server pattern; **may be `""`** (empty). **Ask the user** (see below).                                                                        |
+| `language`     | RNGS language code: one of `en`, `ar`, `fr`, `es`, `de`, `it`, `ja`, `pt`, `ru` (usually `en`).                                                      |
+| `title`        | The graphic pack's title. Describes the specific topic the graphics pack covers, e.g., "Iran crisis blog". 3–150 characters.                         |
+| `description`  | The graphic pack's description. Often kept as short as the string "Graphic:". 3–150 characters.                                                      |
+| `contactEmail` | A valid email ending in `@thomsonreuters.com`.                                                                                                       |
+| `authors`      | Array with **at least one** entry; each requires a `name` (≥3 chars) and a `link` (valid URL). (Sourced by the publisher from the `byline` pointer.) |
 
 Under each `reuters.graphic.archives.<id>`:
 
-| Field | Requirement |
-|---|---|
-| `title` | The archive's specific title (≥3 chars). Describes the specific graphic it contains. Shares a 255-char budget with the pack title — see below. |
-| `description` | The archive's description; **doubles as the graphic's alt text**. Shares a 255-char budget with the pack description — see below. |
+| Field         | Requirement                                                                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`       | The archive's specific title (≥3 chars). Describes the specific graphic it contains. Shares a 255-char budget with the pack title — see below. |
+| `description` | The archive's description; **doubles as the graphic's alt text**. Shares a 255-char budget with the pack description — see below.              |
 
 Everything else — the pack-level `pack`, `preview`, `separateAssets`, `published`, `updated`, top-level `homepage`, and each archive's `url`, `uploaded` and `editions` — is written by the server. ⛔ Never set or edit those (rule 2).
 
@@ -105,27 +110,27 @@ Use `PKG` getters for typed access instead of reading `package.json` directly:
 ```typescript
 import { PKG } from '@reuters-graphics/graphics-kit-publisher';
 
-PKG.homepage;                       // 'https://www.reuters.com/graphics/.../'
-PKG.preview;                        // preview URL
-PKG.separateAssets;                 // S3 assets.zip URL
-PKG.pack.id;                        // Sphinx pack ID
-PKG.pack.desk;                      // 'london'
-PKG.pack.rootSlug;                  // 'ROOT-SLUG'
-PKG.pack.wildSlug;                  // 'WILD'
-PKG.pack.language;                  // 'en'
+PKG.homepage; // 'https://www.reuters.com/graphics/.../'
+PKG.preview; // preview URL
+PKG.separateAssets; // S3 assets.zip URL
+PKG.pack.id; // Sphinx pack ID
+PKG.pack.desk; // 'london'
+PKG.pack.rootSlug; // 'ROOT-SLUG'
+PKG.pack.wildSlug; // 'WILD'
+PKG.pack.language; // 'en'
 PKG.pack.contactEmail;
 PKG.pack.title;
-PKG.pack.description;               // defaults to 'Graphic'
-PKG.pack.authors;                   // [{ name, link }, ...]
-PKG.pack.published;                 // ISO timestamp of first publish
-PKG.pack.updated;                   // ISO timestamp of latest publish
+PKG.pack.description; // defaults to 'Graphic'
+PKG.pack.authors; // [{ name, link }, ...]
+PKG.pack.published; // ISO timestamp of first publish
+PKG.pack.updated; // ISO timestamp of latest publish
 
 // Archive metadata is accessed by archive ID:
 PKG.archive('media-en-page').url;
 PKG.archive('media-en-page').title;
 PKG.archive('media-en-page').description;
 PKG.archive('media-en-page').uploaded;
-PKG.archive('media-en-page').editions;   // ['interactive', 'media-interactive', 'EPS', 'JPG']
+PKG.archive('media-en-page').editions; // ['interactive', 'media-interactive', 'EPS', 'JPG']
 ```
 
 The `PKG` properties technically work as setters too (the publisher uses them internally), but **avoid setting them** — e.g. `PKG.homepage = '...'` is almost always a mistake.
@@ -164,14 +169,17 @@ export default defineConfig({
     pack: {
       rootSlug: 'locales/en/content.json?story.rootSlug',
       wildSlug: 'locales/en/content.json?story.wildSlug',
-      desk: { path: '~/.reuters-graphics/profile.json?desk', promptAsInitial: true },
-      language: 'en',                                   // no shorthand — a bare string is a language code
+      desk: {
+        path: '~/.reuters-graphics/profile.json?desk',
+        promptAsInitial: true,
+      },
+      language: 'en', // no shorthand — a bare string is a language code
       title: 'dist/index.html?title',
       byline: 'locales/en/content.json?story.authors',
       contactEmail: '~/.reuters-graphics/profile.json?email',
     },
     edition: {
-      title: 'index.html?title',                        // file path is relative to the edition root
+      title: 'index.html?title', // file path is relative to the edition root
       description: 'index.html?meta.og:description',
     },
   },

--- a/llms/pack-metadata.md
+++ b/llms/pack-metadata.md
@@ -1,0 +1,182 @@
+---
+name: Pack metadata
+description: The pack metadata the publisher reads and writes — the package.json `reuters` key, the PKG getters, and metadata pointers that source values from project files.
+---
+
+# Pack metadata
+
+Pack metadata lives in the project's `package.json`. It flows two ways:
+
+1. **Sourced before upload** — values the **Sphinx server requires** to create or update a pack (title, slugs, authors, desk, description, contactEmail, …). Before uploading, the publisher fills each from a [metadata pointer](#sourcing-metadata-pointers) if one resolves, and otherwise **prompts the human running the CLI** to type it in. ✅ **You MAY write or edit this metadata.** Writing these values into `package.json` yourself satisfies the server's requirement up front, so the publisher already has them and the upload doesn't stall on interactive prompts an agent can't answer. Changes propagate to the server pack on the next upload.
+2. **Written back after upload** — the graphics server returns IDs, URLs and timestamps (`pack` ID, archive `url`s, `published`/`updated`/`uploaded`, `preview`, `separateAssets`, `homepage`, and each archive's `editions` list), which the publisher saves under the `reuters` key. ⛔ **NEVER write or edit this metadata.** It reflects authoritative server state; editing it desynchronizes the local project from the graphics server and can corrupt or orphan the pack. Only the publisher should write these values.
+
+## The `reuters` key
+
+After uploading, metadata is saved mostly under `reuters` (plus a top-level `homepage`):
+
+```jsonc
+{
+  "reuters": {
+    "preview": "https://graphics.thomsonreuters.com/.../",       // preview URL
+    "separateAssets": "https://graphics.thomsonreuters.com/.../assets.zip",
+    "graphic": {
+      "pack": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",             // pack ID in Sphinx
+      "desk": "london",
+      "slugs": { "root": "ROOT-SLUG", "wild": "WILD" },
+      "contactEmail": "jane.doe@thomsonreuters.com",
+      "title": "A title",
+      "description": "Graphic",                                    // defaults to "Graphic"
+      "authors": [{ "name": "Jane Doe", "link": "https://www.reuters.com/authors/jane-doe/" }],
+      "published": "2025-02-23T00:00:00.000Z",                     // first publish
+      "updated": "2025-02-24T00:00:00.000Z",                       // latest publish
+      "archives": {
+        "public": {
+          "url": "https://www.reuters.com/graphics/.../",
+          "title": "A title",
+          "description": "A description",
+          "uploaded": "2025-02-24T00:00:00.000Z",
+          "editions": ["interactive"]
+        },
+        "media-en-page": {
+          "url": "https://www.reuters.com/graphics/.../",
+          "editions": ["interactive", "media-interactive", "EPS", "JPG"]
+        }
+      }
+    }
+  },
+  "homepage": "https://www.reuters.com/graphics/.../"              // set if a `public` archive exists
+}
+```
+
+The `archives` object is keyed by **archive ID** (e.g. `public`, `media-en-page`); each records its URL, title/description, last-uploaded timestamp and the list of editions it contains.
+
+Within this block, only the **human-authored** fields may be edited — an archive's `title` and `description`, and the pack-level `title`, `description`, `desk`, `authors`, `slugs` and `contactEmail`. Editing them updates the server pack on the next upload. ⛔ Everything the server writes back — `pack` ID, `url`s, `uploaded`/`published`/`updated`, `preview`, `separateAssets`, `homepage` and each archive's `editions` list — must **NEVER** be edited by hand; those tie the local project to server records and editing them desynchronizes or corrupts the pack.
+
+## Required fields you may set
+
+These fields are **required by the Sphinx server** to upload a pack _and_ are human-authored, so an agent may fill or edit them (rule 1 above). Pre-filling them lets an upload run without stopping for CLI prompts — **except the slugs, which you should ask the user for** (see below).
+
+Under `reuters.graphic`:
+
+| Field | Requirement |
+|---|---|
+| `desk` | One of `london`, `new york`, `singapore`, `bengaluru`. |
+| `slugs.root` | Strict server pattern; identifies the graphic in URLs. **Ask the user — do not invent one** (see below). |
+| `slugs.wild` | Strict server pattern; **may be `""`** (empty). **Ask the user** (see below). |
+| `language` | RNGS language code: one of `en`, `ar`, `fr`, `es`, `de`, `it`, `ja`, `pt`, `ru` (usually `en`). |
+| `title` | The graphic pack's title. Describes the specific topic the graphics pack covers, e.g., "Iran crisis blog". 3–150 characters. |
+| `description` | The graphic pack's description. Often kept as short as the string "Graphic:". 3–150 characters. |
+| `contactEmail` | A valid email ending in `@thomsonreuters.com`. |
+| `authors` | Array with **at least one** entry; each requires a `name` (≥3 chars) and a `link` (valid URL). (Sourced by the publisher from the `byline` pointer.) |
+
+Under each `reuters.graphic.archives.<id>`:
+
+| Field | Requirement |
+|---|---|
+| `title` | The archive's specific title (≥3 chars). Describes the specific graphic it contains. Shares a 255-char budget with the pack title — see below. |
+| `description` | The archive's description; **doubles as the graphic's alt text**. Shares a 255-char budget with the pack description — see below. |
+
+Everything else — the pack-level `pack`, `preview`, `separateAssets`, `published`, `updated`, top-level `homepage`, and each archive's `url`, `uploaded` and `editions` — is written by the server. ⛔ Never set or edit those (rule 2).
+
+### Slugs: ask the user, don't generate them
+
+`slugs.root` and `slugs.wild` identify the graphic in the graphics server and in its public URLs, and the server validates them against strict patterns. A wrong or invented value is costly to change later. **Prompt the user for both** rather than guessing — do not derive them from the project name, title or filenames.
+
+Roughly, to _validate_ what the user provides:
+
+- **root** — uppercase segments joined by hyphens: 2–5 segments, at least one hyphen; each segment is letters/digits plus `&`, `.`, `'`, with single spaces allowed inside a segment. Example: `HEALTH-CORONAVIRUS`.
+- **wild** — uppercase letters/digits with `&`, `.`, `'`, `-` and spaces; **may be empty**; may end with a parenthetical list like `(MAP, CHART)`. Example: `MAP`.
+
+The exact regexes — and the rules for every other field in this section (lengths, email domain, author shape, allowed `desk`/`language` values) — are defined by the publisher's [valibot](https://valibot.dev/) schemas in `src/validators/pack.ts`. **Treat that module as the source of truth** rather than copying patterns here, which can drift.
+
+### Title & description share a 255-char budget with the pack
+
+For each archive, the server caps the **combined** length of the pack string and the archive string at 255 characters:
+
+- `archive.title` length must be `< 255 − pack.title` length
+- `archive.description` length must be `< 255 − pack.description` length
+
+Because the **archive description is also used as the graphic's alt text**, the convention is to keep the **pack `description` very short** — often just `"Graphic:"` — so the archive description keeps as much of the 255-char budget as possible to describe the graphic well. Keep the pack `title` short for the same reason. (The pack's own `title`/`description` are still independently capped at 150 characters.)
+
+## Reading metadata: the `PKG` module
+
+Use `PKG` getters for typed access instead of reading `package.json` directly:
+
+```typescript
+import { PKG } from '@reuters-graphics/graphics-kit-publisher';
+
+PKG.homepage;                       // 'https://www.reuters.com/graphics/.../'
+PKG.preview;                        // preview URL
+PKG.separateAssets;                 // S3 assets.zip URL
+PKG.pack.id;                        // Sphinx pack ID
+PKG.pack.desk;                      // 'london'
+PKG.pack.rootSlug;                  // 'ROOT-SLUG'
+PKG.pack.wildSlug;                  // 'WILD'
+PKG.pack.language;                  // 'en'
+PKG.pack.contactEmail;
+PKG.pack.title;
+PKG.pack.description;               // defaults to 'Graphic'
+PKG.pack.authors;                   // [{ name, link }, ...]
+PKG.pack.published;                 // ISO timestamp of first publish
+PKG.pack.updated;                   // ISO timestamp of latest publish
+
+// Archive metadata is accessed by archive ID:
+PKG.archive('media-en-page').url;
+PKG.archive('media-en-page').title;
+PKG.archive('media-en-page').description;
+PKG.archive('media-en-page').uploaded;
+PKG.archive('media-en-page').editions;   // ['interactive', 'media-interactive', 'EPS', 'JPG']
+```
+
+The `PKG` properties technically work as setters too (the publisher uses them internally), but **avoid setting them** — e.g. `PKG.homepage = '...'` is almost always a mistake.
+
+## Sourcing metadata: pointers
+
+`metadataPointers` in `publisher.config.ts` tell the publisher where to read metadata values from other files (JSON or built HTML) so it doesn't have to prompt for everything.
+
+A pointer is either a shorthand `path` string or an object:
+
+```typescript
+{
+  path: 'locales/en/content.json?story.authors',   // "<file path>?<data path within file>"
+  format: (value: string[]) => value.join(', '),   // optional: transform the found value
+  validate: (value: string) => value.length > 3,   // optional: reject invalid values
+  promptAsInitial: false,                           // optional: prefill a prompt vs. use directly
+}
+```
+
+### Path syntax
+
+`path` combines a relative file path and a query into that file, separated by `?`:
+
+- `locales/en/content.json?story.title` → the `story.title` value in that JSON file.
+- `dist/index.html?title` → the `<title>` of the built HTML.
+- `dist/index.html?meta.og:description` → a meta tag's content.
+- `~/.reuters-graphics/profile.json?email` → a value from the user's local profile.
+
+`format` runs on the found value; `validate` returns `true`/`false` to accept/reject; `promptAsInitial: true` uses a found value as the initial value of a user prompt rather than accepting it silently.
+
+### Pointer groups and defaults
+
+```typescript
+export default defineConfig({
+  metadataPointers: {
+    pack: {
+      rootSlug: 'locales/en/content.json?story.rootSlug',
+      wildSlug: 'locales/en/content.json?story.wildSlug',
+      desk: { path: '~/.reuters-graphics/profile.json?desk', promptAsInitial: true },
+      language: 'en',                                   // no shorthand — a bare string is a language code
+      title: 'dist/index.html?title',
+      byline: 'locales/en/content.json?story.authors',
+      contactEmail: '~/.reuters-graphics/profile.json?email',
+    },
+    edition: {
+      title: 'index.html?title',                        // file path is relative to the edition root
+      description: 'index.html?meta.og:description',
+    },
+  },
+});
+```
+
+- `pack.*` pointers source pack-level metadata. `pack.language` is special: a bare string is treated as a literal RNGS language code, not a pointer path.
+- `edition.*` pointers source per-edition metadata; their file paths are **relative to each edition's root folder**.

--- a/llms/page-building.md
+++ b/llms/page-building.md
@@ -1,0 +1,124 @@
+---
+name: Page building & routing rules
+description: The filesystem, routing and build rules the publisher enforces — directory pages, canonical links, base paths, the two-pass build, preview images, and packLocations config.
+---
+
+# Page building & routing rules
+
+The publisher matches a project's **built files** to [editions](./graphics-server.md#editions) using filesystem patterns. To be matched, output must obey these rules.
+
+## Directory-based pages
+
+Every page must live in its own folder as `index.html`. Flat `.html` files are **not** allowed.
+
+```
+dist/about.html          ❌ not allowed
+dist/about/index.html    ✅ ok
+```
+
+## Canonical link (required)
+
+Every page **must** include a canonical `<link>` with the fully-specified URL where it will publish on reuters.com. The publisher relies on it.
+
+```html
+<head>
+  <link rel="canonical" href="https://www.reuters.com/graphics/.../" />
+  <link rel="stylesheet" href="https://www.reuters.com/.../styles.css" />
+</head>
+```
+
+## Base paths
+
+Pages usually need a build-time base path (for canonical links and fully-qualified asset URLs). Use the `getBasePath` utility rather than hardcoding:
+
+```javascript
+// svelte.config.js
+import { getBasePath } from '@reuters-graphics/graphics-kit-publisher';
+
+const mode =
+  process.env.PREVIEW ? 'preview'
+  : process.env.NODE_ENV === 'production' ? 'prod'
+  : 'dev';
+
+const basePath = getBasePath(mode, { trailingSlash: false, rootRelative: true });
+// e.g. "/graphics/ROOT-SLUG/WILD/asdjuspodfg"
+
+const assetsPath = getBasePath(mode, 'cdn', { trailingSlash: false, rootRelative: false });
+// e.g. "https://www.reuters.com/graphics/ROOT-SLUG/WILD/asdjuspodfg/cdn"
+```
+
+`mode` is one of `dev`, `test`, `preview`, `prod`. It reads URLs the publisher has saved to `package.json`:
+
+- **preview**: before the preview build, the publisher generates a unique URL and saves it to `reuters.graphic.preview`, so `getBasePath('preview')` resolves during that build.
+- **prod**: production base URLs come from the graphics server after upload (see the two-pass build below).
+
+## Two-pass production build
+
+The publisher needs to _see_ built files to know which archives to upload, but production pages need server-issued URLs baked in as base paths — a chicken-and-egg problem it solves by building twice:
+
+1. Create the graphic pack in the graphics server.
+2. Build **without** base-path URLs.
+3. Scan the built files to determine which archives/editions exist.
+4. Upload **dummy** files for each archive to obtain its URL from the server; save URLs to `package.json`.
+5. Build the **production** version, which can now use the saved URLs for base paths and canonical links.
+6. Replace the dummy archives with the real built files.
+
+## Build logs & diagnosing failures
+
+The publisher runs the project's own build scripts as a child process — `build:preview` for `preview`, `build` for `upload`/`publish` (see [`build.scripts`](./config.md#build)). If a build **fails**, the command aborts: `preview` and `upload` cannot complete, and the publisher raises a build error.
+
+Every build writes its captured output to `.graphics-kit/logs/`, whether it succeeds or fails:
+
+- `.graphics-kit/logs/error.log` — the build's `stderr`. **Start here to diagnose a failed build.**
+- `.graphics-kit/logs/out.log` — the build's `stdout`.
+
+Each file is overwritten on every build and prefixed with a timestamp. So when a `preview` or `upload` fails at the build step, read `error.log` to find the underlying error in the project's code — that's almost always the real problem, not the publisher itself. (`.graphics-kit/` is a working directory the publisher manages; it's excluded from packed archives.)
+
+## Preview images
+
+[Interactive](./graphics-server.md#edition-types) editions need an image for previews (graphics server, Lynx, Reuters Connect). Provide one of:
+
+- an `og:image` meta tag in the page (if the image is among the build's assets):
+  ```html
+  <meta property="og:image" content="https://www.reuters.com/graphics/.../share.jpg" />
+  ```
+- or an image file at the edition root named `_gfxpreview.png` or `_gfxpreview.jpg`.
+
+Valid preview types: `.jpg`, `.jpeg`, `.png`.
+
+## packLocations (mapping built files → editions)
+
+`packLocations` in `publisher.config.ts` tells the publisher where each kind of output lives. Each can be set to `false` if the project has none of that type.
+
+```typescript
+export default defineConfig({
+  packLocations: {
+    dotcom: 'dist/',                         // default
+    embeds: 'dist/embeds/{locale}/{slug}/',  // default
+    statics: 'media-assets/{locale}/{slug}/',// default
+  },
+});
+```
+
+- **dotcom** — directory holding the reuters.com page(s); must contain a root `index.html`. Becomes the `public` archive.
+- **embeds** — a pattern capturing every embeddable page directory; each must contain a root `index.html`. The pattern **must** include `{locale}` and `{slug}` capture groups, which name the resulting `media-{locale}-{slug}` archives/editions.
+- **statics** — a pattern capturing directories of static/editable graphics; each must contain at least one static file (`.eps`, `.jpg`, `.png`, `.pdf`) at its root. Also requires `{locale}` and `{slug}` capture groups.
+
+Example — `embeds: 'dist/embeds/{locale}/{slug}/'` captures:
+
+```
+dist/embeds/
+├── en/          {locale}
+│   ├── page/    {slug}   → index.html
+│   └── map/     {slug}   → index.html
+└── de/          {locale}
+    └── map/     {slug}   → index.html
+```
+
+## Related config
+
+- `build.scripts` — npm script keys for `preview` and `production` builds (defaults: `build:preview`, `build`).
+- `build.outDir` — where the build system writes output (default `dist/`).
+- `publishingLocations` — rules matching archive IDs (string or RegExp) to whether they may publish to `lynx` / `connect`.
+- `archiveEditions` — files added to `media-interactive` editions (`docs`, incl. a required `README.txt`), ignore patterns for the client source zip, and `separateAssets` (a directory uploaded separately to S3).
+- `embedTemplate` — the embed code (`declaration`) and shared `dependencies` for embeddable graphics.

--- a/llms/page-building.md
+++ b/llms/page-building.md
@@ -40,10 +40,16 @@ const mode =
   : process.env.NODE_ENV === 'production' ? 'prod'
   : 'dev';
 
-const basePath = getBasePath(mode, { trailingSlash: false, rootRelative: true });
+const basePath = getBasePath(mode, {
+  trailingSlash: false,
+  rootRelative: true,
+});
 // e.g. "/graphics/ROOT-SLUG/WILD/asdjuspodfg"
 
-const assetsPath = getBasePath(mode, 'cdn', { trailingSlash: false, rootRelative: false });
+const assetsPath = getBasePath(mode, 'cdn', {
+  trailingSlash: false,
+  rootRelative: false,
+});
 // e.g. "https://www.reuters.com/graphics/ROOT-SLUG/WILD/asdjuspodfg/cdn"
 ```
 
@@ -80,7 +86,10 @@ Each file is overwritten on every build and prefixed with a timestamp. So when a
 
 - an `og:image` meta tag in the page (if the image is among the build's assets):
   ```html
-  <meta property="og:image" content="https://www.reuters.com/graphics/.../share.jpg" />
+  <meta
+    property="og:image"
+    content="https://www.reuters.com/graphics/.../share.jpg"
+  />
   ```
 - or an image file at the edition root named `_gfxpreview.png` or `_gfxpreview.jpg`.
 
@@ -93,9 +102,9 @@ Valid preview types: `.jpg`, `.jpeg`, `.png`.
 ```typescript
 export default defineConfig({
   packLocations: {
-    dotcom: 'dist/',                         // default
-    embeds: 'dist/embeds/{locale}/{slug}/',  // default
-    statics: 'media-assets/{locale}/{slug}/',// default
+    dotcom: 'dist/', // default
+    embeds: 'dist/embeds/{locale}/{slug}/', // default
+    statics: 'media-assets/{locale}/{slug}/', // default
   },
 });
 ```

--- a/package.json
+++ b/package.json
@@ -17,8 +17,19 @@
   "private": false,
   "keywords": [],
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "llms/**/*"
   ],
+  "llms": {
+    "description": [
+      "A filesystem-based publisher for Reuters Graphics projects.",
+      "Compiles a project's built pages and static graphics into the archive/edition structure the Sphinx graphics server expects, then uploads them for publishing to reuters.com and to media clients via Reuters Connect.",
+      "You're most likely working with it in a project that has a `publisher.config.ts`, a `reuters` key in its `package.json`, or `preview`, `upload` and `pub` npm scripts — i.e. when building, previewing, publishing, or wiring up base paths, pack metadata or embed codes for a graphic."
+    ],
+    "files": [
+      "./llms/**/*"
+    ]
+  },
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "build:docs": "astro build",

--- a/src/validators/pack.ts
+++ b/src/validators/pack.ts
@@ -99,7 +99,7 @@ export const Title = v.pipe(
   v.trim(),
   v.nonEmpty('Title is required'),
   v.minLength(3, 'Title must be at least 3 characters'),
-  v.maxLength(150, 'Description must be less than 150 characters')
+  v.maxLength(150, 'Title must be less than 150 characters')
 );
 
 export const Description = v.pipe(


### PR DESCRIPTION
## Summary

Ships documentation written for **LLM coding agents** as part of the package, so consuming projects (e.g. the graphics kit) can give their agents accurate context about how the publisher works.

- New **`llms/`** folder of terse, agent-oriented reference docs, published to npm.
- New **`llms`** field in `package.json` (`description` + `files` globs) that downstream tooling reads to hoist these docs into a project's `.claude/llms/`.
- New human-facing docs page explaining the docs exist and that library developers may need to update them.
- Drive-by fix: corrected the pack `title` max-length validation message (it said "Description").

## The `llms/` docs

| Doc | Covers |
|---|---|
| `index.md` | Root/entry doc: overview, workflow, and a pointer table linking the rest for on-demand reading. |
| `graphics-server.md` | The Sphinx model — graphic pack → archive → edition, root files, edition types, and RNGS/Lynx/Connect routing. |
| `pack-metadata.md` | The `reuters` key, `PKG` getters, metadata pointers, required fields, slug rules, and the shared 255-char title/description budget. |
| `page-building.md` | Routing/build rules: directory pages, canonical links, base paths, two-pass build, build logs, preview images, `packLocations`. |
| `config.md` | Reference for every `publisher.config.ts` option group. |
| `glossary.md` | Key terms, weighted toward graphics-server concepts. |

## How hoisting works

The consumer reads `llms.files` globs against the installed package (hence `llms/**/*` is added to the npm `files` allowlist), copies the docs into `.claude/llms/graphics-kit-publisher/`, and links `index.md` from its agent instructions. Verified the glob/base-stripping and that all docs ship in the tarball (`npm pack --dry-run`).

## Notable agent-facing guidance captured

- **Metadata edit boundary**: agents MAY pre-fill server-required, human-authored fields (unblocks non-interactive uploads) but must NEVER touch server-written fields (IDs, URLs, timestamps).
- **Slugs**: strict server patterns — instruct agents to ask the user rather than invent them; source of truth is `src/validators/pack.ts`.
- **255-char budget**: pack + archive title/description share a per-archive cap; archive description doubles as alt text.
- **Build logs**: failed `preview`/`upload` builds write to `.graphics-kit/logs/error.log` — check there first.

## Follow-up (separate repo)

`@reuters-graphics/graphics-kit-publisher` needs adding to the `PACKAGES` array in `bluprint_graphics-kit`'s `bin/sync-llms/index.js` before these docs actually hoist there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)