### PR TITLE
fix: exit CLI promptly after commands complete

### DIFF
--- a/.changeset/cli-clean-exit.md
+++ b/.changeset/cli-clean-exit.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Fix CLI hanging for ~1–2 minutes after commands finished. The CLI now exits promptly once a command resolves instead of waiting on keep-alive sockets held open by dependencies (e.g. the AWS SDK S3 client).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,58 +7,74 @@ const prog = sade('graphics-publisher');
 
 prog.version(version);
 
-prog.command('preview').action(async () => {
+/**
+ * Run a publisher command and exit the process cleanly once it resolves.
+ *
+ * The CLI never called `process.exit()` on success, so the process only exited
+ * when the event loop drained. Dependencies (notably the AWS SDK S3 client) hold
+ * keep-alive sockets open, which kept Node alive for ~1–2 minutes after the
+ * command had otherwise finished. Exiting explicitly here — symmetric with the
+ * `process.exit(1)` in `handleError` — makes the CLI return promptly regardless
+ * of any leaked handles in dependencies.
+ *
+ * This lives in the CLI entrypoint (not the shared `withIntroOutro` decorator)
+ * so it never affects consumers importing `GraphicsKitPublisher` as a library.
+ *
+ * @see https://github.com/reuters-graphics/graphics-kit-publisher/issues/137
+ */
+const runCommand = async (action: () => Promise<void>) => {
   try {
-    const graphicsPublisher = new GraphicsKitPublisher();
-    await graphicsPublisher.preview();
+    await action();
+    exitCleanly(0);
   } catch (error) {
     handleError(error);
   }
-});
+};
 
-prog.command('upload').action(async () => {
-  try {
-    const graphicsPublisher = new GraphicsKitPublisher();
-    await graphicsPublisher.upload();
-  } catch (error) {
-    handleError(error);
+/**
+ * Set the exit code and exit once stdout/stderr have flushed, so buffered output
+ * (e.g. when piped through `npm-run-all`) isn't truncated by `process.exit()`.
+ */
+const exitCleanly = (code: number) => {
+  process.exitCode = code;
+  const streams = [process.stdout, process.stderr];
+  let pending = 0;
+  const done = () => {
+    if (--pending <= 0) process.exit(code);
+  };
+  for (const stream of streams) {
+    if (stream.writableLength > 0) {
+      pending++;
+      stream.once('drain', done);
+    }
   }
-});
+  if (pending === 0) process.exit(code);
+};
 
-prog.command('upload:quick').action(async () => {
-  try {
-    const graphicsPublisher = new GraphicsKitPublisher();
-    await graphicsPublisher.uploadPublicOnly();
-  } catch (error) {
-    handleError(error);
-  }
-});
+prog
+  .command('preview')
+  .action(() => runCommand(() => new GraphicsKitPublisher().preview()));
 
-prog.command('publish').action(async () => {
-  try {
-    const graphicsPublisher = new GraphicsKitPublisher();
-    await graphicsPublisher.publish();
-  } catch (error) {
-    handleError(error);
-  }
-});
+prog
+  .command('upload')
+  .action(() => runCommand(() => new GraphicsKitPublisher().upload()));
 
-prog.command('restart').action(async () => {
-  try {
-    const graphicsPublisher = new GraphicsKitPublisher();
-    await graphicsPublisher.restart();
-  } catch (error) {
-    handleError(error);
-  }
-});
+prog
+  .command('upload:quick')
+  .action(() =>
+    runCommand(() => new GraphicsKitPublisher().uploadPublicOnly())
+  );
 
-prog.command('delete').action(async () => {
-  try {
-    const graphicsPublisher = new GraphicsKitPublisher();
-    await graphicsPublisher.delete();
-  } catch (error) {
-    handleError(error);
-  }
-});
+prog
+  .command('publish')
+  .action(() => runCommand(() => new GraphicsKitPublisher().publish()));
+
+prog
+  .command('restart')
+  .action(() => runCommand(() => new GraphicsKitPublisher().restart()));
+
+prog
+  .command('delete')
+  .action(() => runCommand(() => new GraphicsKitPublisher().delete()));
 
 prog.parse(process.argv);


### PR DESCRIPTION
## Problem

The CLI does its work, prints the `✅ Done.` outro, then **hangs for ~1–2 minutes before the process actually exits** — visible in `npm-run-all` chains where the next command doesn't start for a couple of minutes.

Root cause: `src/cli.ts` never called `process.exit()` on success, so the process only exited once the event loop drained. Dependencies — notably the AWS SDK v3 S3 client used by `preview`/`upload` — keep a keep-alive TCP socket pooled and referenced, keeping Node alive until the *server's* idle timeout finally closes it. (`handleError` already calls `process.exit(1)`, which is why failures exited instantly but successes hung.)

Full investigation and evidence in #137.

## Fix

Wrap each command in a `runCommand` helper that exits cleanly on success via a new `exitCleanly()`, which sets `process.exitCode` and waits for `stdout`/`stderr` to drain before `process.exit()` so piped output isn't truncated.

This lives in the **CLI entrypoint, not the shared `withIntroOutro` decorator** — the package is also published as a library (`GraphicsKitPublisher`), and exiting inside the decorator would kill any host process importing it.

## Verification

Built and run against a real project with a `process.getActiveResourcesInfo()` probe:

- **Before:** held open by `TCPSocketWrap:1` for 115s+ after `Done`.
- **After:** exits ~1s after `Done` (`code=0`), full outro flushed intact.
- `pnpm test`: 142/142 pass.

## Notes

This makes the CLI robust regardless of leaked handles in dependencies. The socket is still opened per-run; the proper teardown (`S3Client.destroy()`) is tracked upstream in reuters-graphics/graphics-bin#66 and can be layered on later.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
