### PR TITLE
chore: update clack deps to v1

### DIFF
--- a/.changeset/update-clack-v1.md
+++ b/.changeset/update-clack-v1.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit-publisher': minor
+---
+
+Update `@clack/prompts` (0.10 → 1.7) and `@reuters-graphics/clack` (0.0.2 → 1.0) to their v1 releases. These are ESM-only and require Node ≥20.12, so the publisher's minimum Node version is now `>=20.12.0`. No consumer-facing API changes.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "graphics-publisher": "./dist/cli.js"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.12.0"
   },
   "packageManager": "pnpm@9.13.2",
   "repository": "reuters-graphics/graphics-kit-publisher",
@@ -80,8 +80,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.688.0",
-    "@clack/prompts": "^0.10.0",
-    "@reuters-graphics/clack": "^0.0.2",
+    "@clack/prompts": "^1.7.0",
+    "@reuters-graphics/clack": "^1.0.0",
     "@reuters-graphics/graphics-bin": "^1.1.8",
     "@reuters-graphics/savile": "^0.0.4",
     "@reuters-graphics/server-client": "^2.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^3.688.0
         version: 3.688.0
       '@clack/prompts':
-        specifier: ^0.10.0
-        version: 0.10.0
+        specifier: ^1.7.0
+        version: 1.7.0
       '@reuters-graphics/clack':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^1.0.0
+        version: 1.0.0
       '@reuters-graphics/graphics-bin':
         specifier: ^1.1.8
         version: 1.1.8
@@ -526,11 +526,16 @@ packages:
   '@clack/core@0.4.1':
     resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
 
-  '@clack/prompts@0.10.0':
-    resolution: {integrity: sha512-H3rCl6CwW1NdQt9rE3n373t7o5cthPv7yUoxF2ytZvyvlJv89C5RYMJu83Hed8ODgys5vpBU0GKxIRG83jd8NQ==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
 
   '@clack/prompts@0.9.1':
     resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1313,8 +1318,8 @@ packages:
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
     engines: {node: '>=18'}
 
-  '@reuters-graphics/clack@0.0.2':
-    resolution: {integrity: sha512-k89PsHgNBIOMcpeolamZmMfkP/GBftIpj+/goPpWoub49oE6ky+CXporzmwU08qNafr0O5tGxr8lSVxT98qxmw==}
+  '@reuters-graphics/clack@1.0.0':
+    resolution: {integrity: sha512-0uMSZXOEnfJm0YC2V8FheUdX9mYpJcOr8q0gRJ1k7riJ7CxH4HyLMGCG18g+aZkiFquS9uKNV0IMIRbFqTijJg==}
     engines: {node: '>=18.0.0'}
 
   '@reuters-graphics/graphics-bin@1.1.8':
@@ -3176,11 +3181,20 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-text-encoding@1.0.6:
     resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
 
   fast-uri@3.0.3:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
@@ -6757,16 +6771,22 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.10.0':
+  '@clack/core@1.4.3':
     dependencies:
-      '@clack/core': 0.4.1
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@clack/prompts@0.9.1':
     dependencies:
       '@clack/core': 0.4.1
       picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
   '@colors/colors@1.6.0': {}
@@ -7483,9 +7503,10 @@ snapshots:
 
   '@publint/pack@0.1.2': {}
 
-  '@reuters-graphics/clack@0.0.2':
+  '@reuters-graphics/clack@1.0.0':
     dependencies:
-      '@clack/core': 0.4.1
+      '@clack/core': 1.4.3
+      '@clack/prompts': 1.7.0
       is-unicode-supported: 2.1.0
       picocolors: 1.1.1
 
@@ -9763,9 +9784,19 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-text-encoding@1.0.6: {}
 
   fast-uri@3.0.3: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-parser@4.4.1:
     dependencies:

--- a/src/build/validate.test.ts
+++ b/src/build/validate.test.ts
@@ -9,6 +9,10 @@ const mockSpinner = {
   stop: vi.fn(),
   start: vi.fn(),
   message: vi.fn(),
+  cancel: vi.fn(),
+  error: vi.fn(),
+  clear: vi.fn(),
+  isCancelled: false,
 };
 
 // Mock the context, logs, and note

--- a/src/prompts/text.ts
+++ b/src/prompts/text.ts
@@ -54,7 +54,10 @@ export const text = async ({
     message,
     initialValue,
     placeholder,
-    validate,
+    // clack@1 widened `validate`'s argument to `string | undefined` (a blank
+    // prompt yields `undefined`); coerce to '' so our `(value: string) => …`
+    // validators keep working.
+    validate: validate ? (value) => validate(value ?? '') : undefined,
   });
 
   if (isCancel(value)) {


### PR DESCRIPTION
## What

Updates both clack packages to their v1 releases:

- `@clack/prompts`: **0.10.0 → 1.7.0**
- `@reuters-graphics/clack`: **0.0.2 → 1.0.0** (pins `@clack/prompts@^1.7.0`)

These are **major** bumps, not patches. A changeset is included (`minor` — new Node floor, no consumer-facing API change).

## Code changes required by the v1 API

- **`src/prompts/text.ts`** — clack@1 widened the `validate` callback's argument to `string | undefined` (a blank prompt now yields `undefined`, since `placeholder` is no longer a tabbable value). Coerced to `''` so existing `(value: string) => …` validators keep working.
- **`src/build/validate.test.ts`** — extended the spinner mock with the new `SpinnerResult` members (`cancel`, `error`, `clear`, `isCancelled`) that clack@1 added when it split `stop()` into `stop`/`cancel`/`error`.

All existing `spinner.stop(msg)` calls pass only a message (no exit-code arg), so the `stop()` split didn't otherwise affect prod code.

## Node version

clack@1 is ESM-only and requires **Node ≥20.12**, so `engines.node` is bumped `>=18.0.0` → `>=20.12.0`. CI already tests on Node `[20, 22]`, both of which satisfy this.

## Verification

- `tsc --noEmit` clean
- **142/142 tests pass**
- `pnpm build` succeeds

## Note for reviewers

Purely visual clack@1 behavior changes (not breaking): `note` no longer dims lines by default, and `select`/`multiselect` now show a keyboard-instructions footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)