### PR TITLE
feat: structured errors, diagnostics file, improved error output (#141 pt 1)

### DIFF
--- a/.changeset/error-diagnostics.md
+++ b/.changeset/error-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit-publisher': minor
+---
+
+Improve error diagnostics (issue #141, part 1 of 2). Custom errors now extend a `PublisherError` base class carrying a machine-readable `code`, the running `command`, `logPaths`, a remediation `hint`, and structured `context`. On any failure the CLI writes a prompt-ready, secret-redacted diagnostics file to `.graphics-kit/diagnostics/latest.md` (only when git-ignored, so it can't be committed), and the terminal output now leads with a heuristic "likely cause" from the build logs plus the fix hint, hiding the raw stack behind `--verbose`/`DEBUG`.

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -7,26 +7,6 @@ import { spinner } from '@clack/prompts';
 import { cleanOutDir, deleteZeroLengthFiles } from './clean';
 import { validateOutDir } from './validate';
 import { logs } from '../logging';
-import { note } from '@reuters-graphics/clack';
-import dedent from 'dedent';
-import picocolors from 'picocolors';
-import { reflowText } from '../utils/reflowText';
-
-const formatErrorConsoleLog = (err: string) => {
-  if (err.trim().length === 0) return '';
-  const reflowedErrors = reflowText(err.trim(), 80);
-  return (
-    '\nPossible errors found:\n\n' +
-    reflowedErrors
-      .slice(0, 10)
-      .map((line) => (line.length > 80 ? line.slice(0, 75) + ' ...' : line))
-      .map((e) => `${picocolors.bold(picocolors.red(e.trim()))}\n`)
-      .join('') +
-    (reflowedErrors.length > 10 ?
-      `${picocolors.dim(picocolors.red(`+${reflowedErrors.length - 10} more error lines...`))}\n`
-    : '')
-  );
-};
 
 /**
  * Calls a project's build script and validates the build process completed successfully
@@ -41,7 +21,15 @@ const buildApp = async (buildScript: string) => {
 
   if (!pkg.scripts[buildScript]) {
     throw new PackageConfigError(
-      `package.json has no "${buildScript}" script. Check your package scripts or adjust your publisher config.`
+      `package.json has no "${buildScript}" script.`,
+      {
+        code: 'MISSING_BUILD_SCRIPT',
+        hint: 'Add the script to package.json, or point the publisher config at the right script name.',
+        context: {
+          buildScript,
+          availableScripts: Object.keys(pkg.scripts ?? {}),
+        },
+      }
     );
   }
 
@@ -65,8 +53,15 @@ const buildApp = async (buildScript: string) => {
       stderr += data.toString();
     });
 
-    child.on('error', () => {
-      reject(new BuildError('App failed to build'));
+    child.on('error', (cause) => {
+      reject(
+        new BuildError(`Could not start the "${buildScript}" build script.`, {
+          code: 'BUILD_SPAWN_FAILED',
+          hint: `Check that "${buildScript}" runs on its own (e.g. \`${pkgMgr?.agent || 'npm'} run ${buildScript}\`).`,
+          context: { buildScript, packageManager: pkgMgr?.agent },
+          cause,
+        })
+      );
     });
 
     child.on('close', (code) => {
@@ -76,17 +71,17 @@ const buildApp = async (buildScript: string) => {
 
       if (code !== 0) {
         s.stop('Build failed');
-
-        const errorsLog = formatErrorConsoleLog(stderr);
-
-        note(
-          dedent`Your project failed to build. This usually means there's an error somewhere in\nyour app's code.
-          ${errorsLog}
-          See the full logs in ${picocolors.cyan(logs.logDirName)} to diagnose what went wrong.
-          `,
-          '🚨 Build error'
+        reject(
+          new BuildError(
+            "Your project failed to build. This usually means there's an error in your app's code.",
+            {
+              code: 'BUILD_FAILED',
+              logPaths: [logs.errLogPath, logs.outLogPath],
+              hint: `See the full logs in ${logs.logDirName} to diagnose what went wrong.`,
+              context: { buildScript, exitCode: code },
+            }
+          )
         );
-        reject(new BuildError('App failed to build'));
         return;
       }
 

--- a/src/build/validate.ts
+++ b/src/build/validate.ts
@@ -35,7 +35,12 @@ const validateOutDirFileTypes = (s: ReturnType<typeof spinner>) => {
       'Invalid file types'
     );
     throw new InvalidFileTypeError(
-      `Found invalid file types in this project's built files.`
+      `Found invalid file types in this project's built files.`,
+      {
+        code: 'INVALID_BUILT_FILE_TYPES',
+        hint: 'Remove the listed files from your build output — the graphics server rejects these types.',
+        context: { invalidFiles: warnFiles, allowed: VALID_FILE_TYPES },
+      }
     );
   }
 };
@@ -60,7 +65,13 @@ const validateOutDirIndex = (s: ReturnType<typeof spinner>) => {
       'Build error'
     );
     throw new FileSystemError(
-      `Build did not create a root index.html file in ${outDir}.`
+      `Build did not create a root index.html file in ${outDir}.`,
+      {
+        code: 'MISSING_INDEX_HTML',
+        logPaths: [logs.errLogPath, logs.outLogPath],
+        hint: `See the logs in ${logs.logDirName} for details from the build process.`,
+        context: { outDir },
+      }
     );
   }
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 import sade from 'sade';
 import { version } from '../package.json';
 import { GraphicsKitPublisher } from '.';
-import { handleError } from './exceptions/errors';
+import { handleError, PublisherError } from './exceptions/errors';
+import { writeDiagnostics } from './diagnostics';
 
 const prog = sade('graphics-publisher');
 
@@ -22,12 +23,15 @@ prog.version(version);
  *
  * @see https://github.com/reuters-graphics/graphics-kit-publisher/issues/137
  */
-const runCommand = async (action: () => Promise<void>) => {
+const runCommand = async (command: string, action: () => Promise<void>) => {
   try {
     await action();
     exitCleanly(0);
   } catch (error) {
-    handleError(error);
+    // Stamp the command onto the error at the boundary (throw sites don't know it).
+    if (error instanceof PublisherError) error.command = command;
+    const diagnosticsPath = writeDiagnostics(error, command);
+    handleError(error, { command, diagnosticsPath });
   }
 };
 
@@ -53,28 +57,40 @@ const exitCleanly = (code: number) => {
 
 prog
   .command('preview')
-  .action(() => runCommand(() => new GraphicsKitPublisher().preview()));
+  .action(() =>
+    runCommand('preview', () => new GraphicsKitPublisher().preview())
+  );
 
 prog
   .command('upload')
-  .action(() => runCommand(() => new GraphicsKitPublisher().upload()));
+  .action(() =>
+    runCommand('upload', () => new GraphicsKitPublisher().upload())
+  );
 
 prog
   .command('upload:quick')
   .action(() =>
-    runCommand(() => new GraphicsKitPublisher().uploadPublicOnly())
+    runCommand('upload:quick', () =>
+      new GraphicsKitPublisher().uploadPublicOnly()
+    )
   );
 
 prog
   .command('publish')
-  .action(() => runCommand(() => new GraphicsKitPublisher().publish()));
+  .action(() =>
+    runCommand('publish', () => new GraphicsKitPublisher().publish())
+  );
 
 prog
   .command('restart')
-  .action(() => runCommand(() => new GraphicsKitPublisher().restart()));
+  .action(() =>
+    runCommand('restart', () => new GraphicsKitPublisher().restart())
+  );
 
 prog
   .command('delete')
-  .action(() => runCommand(() => new GraphicsKitPublisher().delete()));
+  .action(() =>
+    runCommand('delete', () => new GraphicsKitPublisher().delete())
+  );
 
 prog.parse(process.argv);

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -18,13 +18,23 @@ export const loadUserConfig = async () => {
 
   if (!fs.existsSync(pkgPath)) {
     throw new FileSystemError(
-      `Could not find "package.json" in ${process.cwd()}. Publisher must be run from the root of the project.`
+      `Could not find "package.json" in ${process.cwd()}.`,
+      {
+        code: 'NOT_PROJECT_ROOT',
+        hint: 'Run the publisher from the root of your project (where package.json lives).',
+        context: { cwd: process.cwd() },
+      }
     );
   }
 
   if (!fs.existsSync(configPath)) {
     throw new FileNotFoundError(
-      `Could not find "publisher.config.ts" in ${process.cwd()}`
+      `Could not find "publisher.config.ts" in ${process.cwd()}`,
+      {
+        code: 'MISSING_PUBLISHER_CONFIG',
+        hint: 'Add a publisher.config.ts to your project root (see the publisher docs / `defineConfig`).',
+        context: { configPath },
+      }
     );
   }
 

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -125,7 +125,7 @@ export const validateConfig = (config: Config) => {
       }
       throw new ConfigError(errorMessages.join('\n'), {
         code: 'INVALID_CONFIG',
-        hint: 'Fix the listed fields in your publisher config (publisher.config.ts or the `reuters` key in package.json).',
+        hint: 'Fix the listed fields in your publisher.config.ts.',
         context: { issues },
         cause: err,
       });

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -117,13 +117,23 @@ export const validateConfig = (config: Config) => {
   } catch (err: unknown) {
     if (v.isValiError(err)) {
       const errorMessages: string[] = [];
+      const issues: { path: string; message: string }[] = [];
       for (const e of err.issues) {
-        const dotPath = v.getDotPath(e);
+        const dotPath = v.getDotPath(e) ?? '(root)';
         errorMessages.push(`${dotPath} ${e.message}`);
+        issues.push({ path: dotPath, message: e.message });
       }
-      throw new ConfigError(errorMessages.join('\n'));
+      throw new ConfigError(errorMessages.join('\n'), {
+        code: 'INVALID_CONFIG',
+        hint: 'Fix the listed fields in your publisher config (publisher.config.ts or the `reuters` key in package.json).',
+        context: { issues },
+        cause: err,
+      });
     }
-    throw new ConfigError('unknown config error');
+    throw new ConfigError('unknown config error', {
+      code: 'UNKNOWN_CONFIG_ERROR',
+      cause: err,
+    });
   }
   return;
 };

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -26,7 +26,11 @@ export class Context {
   private _validateCWD() {
     const cwd = process.cwd();
     if (!fs.existsSync(path.join(cwd, 'package.json'))) {
-      throw new LocationError('Must run publisher from project root');
+      throw new LocationError('Must run publisher from project root', {
+        code: 'NOT_PROJECT_ROOT',
+        hint: 'Run the publisher from the root of your project (where package.json lives).',
+        context: { cwd },
+      });
     }
     return cwd;
   }

--- a/src/diagnostics/index.test.ts
+++ b/src/diagnostics/index.test.ts
@@ -52,7 +52,9 @@ describe('writeDiagnostics', () => {
     vi.clearAllMocks();
   });
 
-  it('writes latest.md when .graphics-kit is git-ignored', () => {
+  const GITIGNORE = '/fake/project/.gitignore';
+
+  it('writes latest.md when .graphics-kit is already git-ignored (no .gitignore edit)', () => {
     mockFs(projectFs({ gitignore: '.graphics-kit/\nnode_modules/' }));
 
     const written = writeDiagnostics(buildErr(), 'upload');
@@ -66,24 +68,41 @@ describe('writeDiagnostics', () => {
     // secret from the log tail is redacted
     expect(content).not.toContain('abcdef0123456789abcdef0123456789abcdef01');
     expect(content).toContain('[redacted]');
+    // already ignored → no edit, no note
+    expect(fs.readFileSync(GITIGNORE, 'utf8')).toBe(
+      '.graphics-kit/\nnode_modules/'
+    );
+    expect(note).not.toHaveBeenCalled();
   });
 
-  it('skips and warns when the path is not git-ignored', () => {
+  it('appends .graphics-kit/ to .gitignore when not yet ignored, then writes', () => {
     mockFs(projectFs({ gitignore: 'node_modules/' }));
 
     const written = writeDiagnostics(buildErr(), 'upload');
 
-    expect(written).toBeNull();
+    expect(written).toBe(LATEST);
+    expect(fs.existsSync(LATEST)).toBe(true);
+    expect(fs.readFileSync(GITIGNORE, 'utf8')).toContain('.graphics-kit/');
     expect(note).toHaveBeenCalled();
-    expect(fs.existsSync(LATEST)).toBe(false);
   });
 
-  it('writes anyway when not in a git repo', () => {
+  it('creates a .gitignore when the git repo has none, then writes', () => {
+    mockFs(projectFs({ gitignore: undefined }));
+
+    const written = writeDiagnostics(buildErr(), 'publish');
+
+    expect(written).toBe(LATEST);
+    expect(fs.existsSync(GITIGNORE)).toBe(true);
+    expect(fs.readFileSync(GITIGNORE, 'utf8')).toContain('.graphics-kit/');
+  });
+
+  it('writes anyway when not in a git repo (no .gitignore created)', () => {
     mockFs(projectFs({ git: false }));
 
     const written = writeDiagnostics(buildErr(), 'preview');
 
     expect(written).toBe(LATEST);
     expect(fs.existsSync(LATEST)).toBe(true);
+    expect(fs.existsSync(GITIGNORE)).toBe(false);
   });
 });

--- a/src/diagnostics/index.test.ts
+++ b/src/diagnostics/index.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import mockFs from 'mock-fs';
+import fs from 'fs';
+import path from 'path';
+
+vi.mock('../context', () => ({
+  context: {
+    cwd: '/fake/project',
+    config: { build: { outDir: 'dist/' } },
+    pkgMgr: { name: 'pnpm', agent: 'pnpm' },
+  },
+}));
+vi.mock('@reuters-graphics/clack', () => ({ note: vi.fn() }));
+
+import { writeDiagnostics } from './index';
+import { BuildError } from '../exceptions/errors';
+import { note } from '@reuters-graphics/clack';
+
+const LATEST = path.join(
+  '/fake/project',
+  '.graphics-kit/diagnostics/latest.md'
+);
+
+const buildErr = () =>
+  new BuildError('App failed to build', {
+    code: 'BUILD_FAILED',
+    logPaths: ['/fake/project/.graphics-kit/logs/error.log'],
+    hint: 'See the logs',
+  });
+
+const projectFs = (opts: {
+  gitignore?: string;
+  git?: boolean;
+}): Parameters<typeof mockFs>[0] => {
+  const project: Record<string, unknown> = {
+    '.graphics-kit': {
+      logs: {
+        'error.log':
+          'src/App.svelte: error TS2304: Cannot find name foo\ntoken=abcdef0123456789abcdef0123456789abcdef01',
+        'out.log': 'built ok',
+      },
+    },
+  };
+  if (opts.git !== false) project['.git'] = { HEAD: 'ref: refs/heads/main' };
+  if (opts.gitignore !== undefined) project['.gitignore'] = opts.gitignore;
+  return { '/fake/project': project } as Parameters<typeof mockFs>[0];
+};
+
+describe('writeDiagnostics', () => {
+  afterEach(() => {
+    mockFs.restore();
+    vi.clearAllMocks();
+  });
+
+  it('writes latest.md when .graphics-kit is git-ignored', () => {
+    mockFs(projectFs({ gitignore: '.graphics-kit/\nnode_modules/' }));
+
+    const written = writeDiagnostics(buildErr(), 'upload');
+
+    expect(written).toBe(LATEST);
+    const content = fs.readFileSync(LATEST, 'utf8');
+    expect(content).toContain('# Publisher diagnostics');
+    expect(content).toContain('BUILD_FAILED');
+    expect(content).toContain('Command: upload');
+    expect(content).toContain('Likely cause');
+    // secret from the log tail is redacted
+    expect(content).not.toContain('abcdef0123456789abcdef0123456789abcdef01');
+    expect(content).toContain('[redacted]');
+  });
+
+  it('skips and warns when the path is not git-ignored', () => {
+    mockFs(projectFs({ gitignore: 'node_modules/' }));
+
+    const written = writeDiagnostics(buildErr(), 'upload');
+
+    expect(written).toBeNull();
+    expect(note).toHaveBeenCalled();
+    expect(fs.existsSync(LATEST)).toBe(false);
+  });
+
+  it('writes anyway when not in a git repo', () => {
+    mockFs(projectFs({ git: false }));
+
+    const written = writeDiagnostics(buildErr(), 'preview');
+
+    expect(written).toBe(LATEST);
+    expect(fs.existsSync(LATEST)).toBe(true);
+  });
+});

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -141,9 +141,8 @@ const buildContent = (error: unknown, command?: string): string => {
   lines.push('');
 
   lines.push('## Project');
-  lines.push(
-    '- Config: `publisher.config.ts` (or the `reuters` key in `package.json`)'
-  );
+  lines.push('- Publisher config: `publisher.config.ts`');
+  lines.push('- Graphic metadata: the `reuters` key in `package.json`');
   lines.push(`- Build output dir: \`${context.config.build.outDir}\``);
   lines.push('');
 

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -1,0 +1,190 @@
+import path from 'path';
+import fs from 'fs';
+import * as find from 'empathic/find';
+import ignore from 'ignore';
+import { utils } from '@reuters-graphics/graphics-bin';
+import { note } from '@reuters-graphics/clack';
+import picocolors from 'picocolors';
+import { context } from '../context';
+import { logs } from '../logging';
+import { PublisherError } from '../exceptions/errors';
+import { extractLikelyErrors } from './likelyError';
+import { redactSecrets } from './redact';
+import { version } from '../../package.json';
+
+const DIAGNOSTICS_DIR = '.graphics-kit/diagnostics/';
+const LLMS_DIR =
+  './node_modules/@reuters-graphics/graphics-kit-publisher/llms/';
+/** Cap each embedded log tail so the file stays a usable prompt. */
+const MAX_LOG_TAIL_BYTES = 8_000;
+
+/**
+ * Decide whether it is safe to write the diagnostics file, i.e. whether it would
+ * be caught by git and never committed.
+ *
+ * - Not a git repo → no commit risk → write.
+ * - Git repo, path git-ignored → write.
+ * - Git repo, path NOT ignored → skip (caller warns), so a file with logs can't
+ *   be accidentally committed.
+ */
+const isSafeToWrite = (cwd: string, relPath: string): boolean => {
+  const gitDir = find.up('.git', { cwd });
+  if (!gitDir) return true;
+
+  const ignoreFile = find.up('.gitignore', { cwd });
+  if (!ignoreFile) return false;
+
+  // `ignore().createFilter()` returns true for paths that are NOT ignored.
+  const notIgnored = ignore()
+    .add(fs.readFileSync(ignoreFile, 'utf8'))
+    .createFilter();
+  return !notIgnored(relPath);
+};
+
+/** Read the last `maxBytes` of a file, or null if it doesn't exist / can't be read. */
+const readTail = (
+  absPath: string,
+  maxBytes: number = MAX_LOG_TAIL_BYTES
+): string | null => {
+  try {
+    if (!fs.existsSync(absPath)) return null;
+    const contents = fs.readFileSync(absPath, 'utf8');
+    return contents.length > maxBytes ?
+        contents.slice(contents.length - maxBytes)
+      : contents;
+  } catch {
+    return null;
+  }
+};
+
+const codeBlock = (body: string, lang = ''): string[] => [
+  '```' + lang,
+  body,
+  '```',
+  '',
+];
+
+/**
+ * Build the diagnostics markdown. Written in the second person as a ready-to-use
+ * prompt: point an agent at the error, the logs, and the publisher's rule docs.
+ */
+const buildContent = (error: unknown, command?: string): string => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  const isPublisherError = err instanceof PublisherError;
+  const cmd = command ?? (isPublisherError ? err.command : undefined);
+
+  const errLog = readTail(logs.errLogPath);
+  const outLog = readTail(logs.outLogPath);
+
+  // Prefer the error's own logPaths (delegated errors); otherwise fall back to error.log.
+  let likely: string[] = [];
+  const logPaths = isPublisherError && err.logPaths ? err.logPaths : [];
+  for (const logPath of logPaths) {
+    const tail = readTail(logPath);
+    if (tail) {
+      likely = extractLikelyErrors(tail, { cwd: context.cwd });
+      if (likely.length) break;
+    }
+  }
+  if (!likely.length && errLog) {
+    likely = extractLikelyErrors(errLog, { cwd: context.cwd });
+  }
+
+  const lines: string[] = [];
+  lines.push('# Publisher diagnostics');
+  lines.push('');
+  lines.push(
+    `You are helping debug a failure of the Reuters Graphics publisher CLI, which ran inside this project (\`${context.cwd}\`). Read the error, the logs, and the publisher's rule docs below, then find the real root cause, cite the offending file or rule, and propose a concrete fix. Ask before editing files.`
+  );
+  lines.push('');
+
+  lines.push('## Environment');
+  lines.push(`- Publisher version: ${version}`);
+  lines.push(`- Command: ${cmd ?? 'unknown'}`);
+  lines.push(`- Node: ${process.version}`);
+  lines.push(`- Platform: ${process.platform}`);
+  lines.push(
+    `- Package manager: ${context.pkgMgr?.agent ?? context.pkgMgr?.name ?? 'unknown'}`
+  );
+  lines.push(`- CI: ${utils.environment.isCiEnvironment()}`);
+  lines.push('');
+
+  lines.push('## Error');
+  lines.push(`- Type: ${err.name}`);
+  if (isPublisherError) lines.push(`- Code: ${err.code}`);
+  lines.push(`- Message: ${err.message}`);
+  if (isPublisherError && err.hint) lines.push(`- Hint: ${err.hint}`);
+  lines.push('');
+  if (isPublisherError && err.context) {
+    lines.push('### Context');
+    lines.push(...codeBlock(JSON.stringify(err.context, null, 2), 'json'));
+  }
+
+  if (likely.length) {
+    lines.push('## Likely cause');
+    lines.push(...codeBlock(likely.join('\n')));
+  }
+
+  if (errLog) {
+    lines.push('## Log: error.log (tail)');
+    lines.push(...codeBlock(errLog.trim()));
+  }
+  if (outLog) {
+    lines.push('## Log: out.log (tail)');
+    lines.push(...codeBlock(outLog.trim()));
+  }
+
+  lines.push('## Publisher rules & docs');
+  lines.push(
+    `The publisher's rule docs live in \`${LLMS_DIR}\`. Read the relevant ones to understand the rule that produced this error.`
+  );
+  lines.push('');
+
+  lines.push('## Project');
+  lines.push(
+    '- Config: `publisher.config.ts` (or the `reuters` key in `package.json`)'
+  );
+  lines.push(`- Build output dir: \`${context.config.build.outDir}\``);
+  lines.push('');
+
+  lines.push('## Task');
+  lines.push('1. Identify the root cause.');
+  lines.push('2. Cite the offending file/line or the publisher rule.');
+  lines.push('3. Propose a concrete fix. Ask before editing.');
+
+  return lines.join('\n');
+};
+
+/**
+ * Write a prompt-ready diagnostics markdown file for a failed command, gated on
+ * the path being git-ignored so it is never committed. Secrets are redacted.
+ *
+ * @returns the absolute path to `latest.md`, or `null` if writing was skipped.
+ */
+export const writeDiagnostics = (
+  error: unknown,
+  command?: string
+): string | null => {
+  const { cwd } = context;
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const relLatest = path.join(DIAGNOSTICS_DIR, 'latest.md');
+
+  if (!isSafeToWrite(cwd, relLatest)) {
+    note(
+      `Add ${picocolors.cyan('.graphics-kit/')} to your ${picocolors.cyan(
+        '.gitignore'
+      )} to enable diagnostics.`,
+      'Diagnostics skipped'
+    );
+    return null;
+  }
+
+  const content = redactSecrets(buildContent(error, command));
+  const absTimestamped = path.join(cwd, DIAGNOSTICS_DIR, `${timestamp}.md`);
+  const absLatest = path.join(cwd, relLatest);
+
+  utils.fs.ensureWriteFile(absTimestamped, content);
+  utils.fs.ensureWriteFile(absLatest, content);
+
+  return absLatest;
+};

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -1,12 +1,8 @@
 import path from 'path';
 import fs from 'fs';
-import * as find from 'empathic/find';
-import ignore from 'ignore';
 import { utils } from '@reuters-graphics/graphics-bin';
-import { note } from '@reuters-graphics/clack';
-import picocolors from 'picocolors';
 import { context } from '../context';
-import { logs } from '../logging';
+import { logs, ensureGraphicsKitIgnored } from '../logging';
 import { PublisherError } from '../exceptions/errors';
 import { extractLikelyErrors } from './likelyError';
 import { redactSecrets } from './redact';
@@ -17,29 +13,6 @@ const LLMS_DIR =
   './node_modules/@reuters-graphics/graphics-kit-publisher/llms/';
 /** Cap each embedded log tail so the file stays a usable prompt. */
 const MAX_LOG_TAIL_BYTES = 8_000;
-
-/**
- * Decide whether it is safe to write the diagnostics file, i.e. whether it would
- * be caught by git and never committed.
- *
- * - Not a git repo → no commit risk → write.
- * - Git repo, path git-ignored → write.
- * - Git repo, path NOT ignored → skip (caller warns), so a file with logs can't
- *   be accidentally committed.
- */
-const isSafeToWrite = (cwd: string, relPath: string): boolean => {
-  const gitDir = find.up('.git', { cwd });
-  if (!gitDir) return true;
-
-  const ignoreFile = find.up('.gitignore', { cwd });
-  if (!ignoreFile) return false;
-
-  // `ignore().createFilter()` returns true for paths that are NOT ignored.
-  const notIgnored = ignore()
-    .add(fs.readFileSync(ignoreFile, 'utf8'))
-    .createFilter();
-  return !notIgnored(relPath);
-};
 
 /** Read the last `maxBytes` of a file, or null if it doesn't exist / can't be read. */
 const readTail = (
@@ -155,35 +128,31 @@ const buildContent = (error: unknown, command?: string): string => {
 };
 
 /**
- * Write a prompt-ready diagnostics markdown file for a failed command, gated on
- * the path being git-ignored so it is never committed. Secrets are redacted.
+ * Write a prompt-ready diagnostics markdown file for a failed command. Secrets
+ * are redacted, and `.graphics-kit/` is ensured git-ignored first so the file is
+ * never committed.
  *
- * @returns the absolute path to `latest.md`, or `null` if writing was skipped.
+ * Best-effort: returns the absolute path to `latest.md`, or `null` if writing
+ * failed (a diagnostics failure must never mask the real error).
  */
 export const writeDiagnostics = (
   error: unknown,
   command?: string
 ): string | null => {
-  const { cwd } = context;
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const relLatest = path.join(DIAGNOSTICS_DIR, 'latest.md');
+  try {
+    const { cwd } = context;
+    ensureGraphicsKitIgnored();
 
-  if (!isSafeToWrite(cwd, relLatest)) {
-    note(
-      `Add ${picocolors.cyan('.graphics-kit/')} to your ${picocolors.cyan(
-        '.gitignore'
-      )} to enable diagnostics.`,
-      'Diagnostics skipped'
-    );
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const content = redactSecrets(buildContent(error, command));
+    const absTimestamped = path.join(cwd, DIAGNOSTICS_DIR, `${timestamp}.md`);
+    const absLatest = path.join(cwd, DIAGNOSTICS_DIR, 'latest.md');
+
+    utils.fs.ensureWriteFile(absTimestamped, content);
+    utils.fs.ensureWriteFile(absLatest, content);
+
+    return absLatest;
+  } catch {
     return null;
   }
-
-  const content = redactSecrets(buildContent(error, command));
-  const absTimestamped = path.join(cwd, DIAGNOSTICS_DIR, `${timestamp}.md`);
-  const absLatest = path.join(cwd, relLatest);
-
-  utils.fs.ensureWriteFile(absTimestamped, content);
-  utils.fs.ensureWriteFile(absLatest, content);
-
-  return absLatest;
 };

--- a/src/diagnostics/likelyError.test.ts
+++ b/src/diagnostics/likelyError.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { extractLikelyErrors } from './likelyError';
+
+describe('extractLikelyErrors', () => {
+  it('returns an empty array for empty input', () => {
+    expect(extractLikelyErrors('')).toEqual([]);
+    expect(extractLikelyErrors('   \n  ')).toEqual([]);
+  });
+
+  it('surfaces a TypeScript error line', () => {
+    const log = [
+      '> build',
+      'transforming...',
+      "src/App.svelte:12:3: error TS2304: Cannot find name 'foo'.",
+      'done',
+    ].join('\n');
+    expect(extractLikelyErrors(log, { cwd: '/proj' }).join('\n')).toContain(
+      'error TS2304'
+    );
+  });
+
+  it('prefers a line referencing the project src over an earlier generic error', () => {
+    const log = [
+      'Error: something generic in a dependency',
+      'at node_modules/x/index.js',
+      'src/routes/+page.svelte: Failed to resolve import "./missing"',
+    ].join('\n');
+    expect(extractLikelyErrors(log, { cwd: '/proj' }).join('\n')).toContain(
+      'src/routes/+page.svelte'
+    );
+  });
+
+  it('falls back to the first N lines when nothing matches', () => {
+    const out = extractLikelyErrors('line one\nline two\nline three', {
+      maxLines: 2,
+    });
+    expect(out.length).toBeLessThanOrEqual(2);
+    expect(out[0]).toBe('line one');
+  });
+});

--- a/src/diagnostics/likelyError.test.ts
+++ b/src/diagnostics/likelyError.test.ts
@@ -30,6 +30,33 @@ describe('extractLikelyErrors', () => {
     );
   });
 
+  it('surfaces a vite-plugin-svelte compile error over surrounding noise', () => {
+    const log = [
+      'vite v8.1.4 building for production...',
+      'transforming (243) src/lib/Foo.svelte',
+      '[plugin:vite-plugin-svelte] src/lib/Chart.svelte:20:4 `$props` is not defined',
+      'error during build:',
+    ].join('\n');
+    expect(extractLikelyErrors(log).join('\n')).toContain('Chart.svelte:20:4');
+  });
+
+  it('surfaces a SassError with its file location', () => {
+    const log = [
+      'rendering chunks...',
+      "src/lib/styles/app.scss:4:1: SassError: Can't find stylesheet to import.",
+      'x Build failed',
+    ].join('\n');
+    expect(extractLikelyErrors(log).join('\n')).toContain('SassError');
+  });
+
+  it('ignores node_modules lines when a project line is also present', () => {
+    const log = [
+      'node_modules/some-dep/dist/index.js: SyntaxError: Unexpected token',
+      'src/routes/+page.ts:3:10: SyntaxError: Unexpected token',
+    ].join('\n');
+    expect(extractLikelyErrors(log).join('\n')).toContain('+page.ts:3:10');
+  });
+
   it('falls back to the first N lines when nothing matches', () => {
     const out = extractLikelyErrors('line one\nline two\nline three', {
       maxLines: 2,

--- a/src/diagnostics/likelyError.ts
+++ b/src/diagnostics/likelyError.ts
@@ -3,21 +3,50 @@ import { reflowText } from '../utils/reflowText';
 /**
  * Ranked toolchain error signatures. Earlier entries are higher priority — when
  * several lines match, the one matching an earlier signature wins.
+ *
+ * Tuned for the stack the publisher actually builds: `vite build` over a
+ * SvelteKit 2 / Svelte 5 / sass project (the bluprint_graphics-kit template).
+ * Ordered specific → generic so a Svelte/sass/Rollup error outranks a bare
+ * `Error:` line.
  */
 const ERROR_SIGNATURES: RegExp[] = [
-  /error TS\d+/i,
-  /\bSyntaxError\b/,
+  // Svelte compiler (surfaced through vite-plugin-svelte)
+  /\[plugin:vite-plugin-svelte\]/i,
+  /\bCompileError\b/,
+  // Sass / PostCSS
+  /\bSassError\b/i,
+  /\[sass\]/i,
+  /Failed to load PostCSS/i,
+  /\[postcss\]/i,
+  // Vite / Rollup / esbuild build failures
+  /failed to resolve import/i,
+  /Could not resolve/i,
+  /\bRollupError\b/,
+  /✘ \[ERROR\]/, // esbuild
   /Transform failed/i,
-  /Failed to resolve import/i,
+  // Node / module resolution
   /Cannot find module/i,
-  /is not exported/i,
-  /Unexpected token/i,
+  /ERR_MODULE_NOT_FOUND/,
+  /Cannot find package/i,
   /\bENOENT\b/,
-  /\[vite\]/i,
+  // SvelteKit prerender (adapter-static)
+  /prerender/i,
+  // TypeScript (rare in `vite build`, but cheap to keep)
+  /error TS\d+/i,
+  // Generic JS runtime/syntax
+  /\bReferenceError\b/,
+  /\bSyntaxError\b/,
+  /\bTypeError\b/,
+  /is not defined\b/,
+  /is not exported\b/,
+  /Unexpected (?:token|end|EOF)/i,
+  // Low-signal fallbacks
+  /error during build:/i,
+  /\[vite[:\]-]/i,
   /\[rollup\]/i,
   /ELIFECYCLE/i,
   /npm ERR!/i,
-  /\bERR!/i,
+  /\bERR!/,
   /\bError:/,
   /\bfailed\b/i,
 ];
@@ -60,8 +89,16 @@ export function extractLikelyErrors(
     const signatureRank = ERROR_SIGNATURES.findIndex((re) => re.test(line));
     if (signatureRank === -1) continue;
 
+    // A line points at the user's own code if it names their src/ tree, a
+    // `.svelte` file, or a `file.ext:line` location — but not if it's inside
+    // node_modules (that's dependency noise, not their bug).
+    const inNodeModules = /node_modules/.test(line);
     const referencesProject =
-      (!!cwd && line.includes(cwd)) || /(^|[^\w])src[\\/]/.test(line);
+      !inNodeModules &&
+      ((!!cwd && line.includes(cwd)) ||
+        /(^|[^\w])src[\\/]/.test(line) ||
+        /\.svelte\b/.test(line) ||
+        /\.(?:svelte|ts|js|mjs|scss|css):\d+/.test(line));
     // Lower score is better; a project reference strongly outranks signature order.
     const score =
       signatureRank - (referencesProject ? PROJECT_REFERENCE_BOOST : 0);

--- a/src/diagnostics/likelyError.ts
+++ b/src/diagnostics/likelyError.ts
@@ -1,0 +1,85 @@
+import { reflowText } from '../utils/reflowText';
+
+/**
+ * Ranked toolchain error signatures. Earlier entries are higher priority — when
+ * several lines match, the one matching an earlier signature wins.
+ */
+const ERROR_SIGNATURES: RegExp[] = [
+  /error TS\d+/i,
+  /\bSyntaxError\b/,
+  /Transform failed/i,
+  /Failed to resolve import/i,
+  /Cannot find module/i,
+  /is not exported/i,
+  /Unexpected token/i,
+  /\bENOENT\b/,
+  /\[vite\]/i,
+  /\[rollup\]/i,
+  /ELIFECYCLE/i,
+  /npm ERR!/i,
+  /\bERR!/i,
+  /\bError:/,
+  /\bfailed\b/i,
+];
+
+/** Boost applied to a line that references the user's own project source. */
+const PROJECT_REFERENCE_BOOST = 100;
+
+export interface ExtractLikelyErrorsOptions {
+  /** Absolute project root; lines mentioning it are preferred. */
+  cwd?: string;
+  /** Max number of lines in the returned window. */
+  maxLines?: number;
+  /** Reflow width. */
+  width?: number;
+}
+
+/**
+ * Heuristically surface the most probable error from captured subprocess output
+ * (e.g. a build's stderr). Prefers lines matching a known error signature,
+ * strongly favouring lines that reference the user's own project, and returns a
+ * small window of context around the best match.
+ *
+ * Falls back to the first N non-empty lines when nothing matches — never worse
+ * than dumping the head of the log.
+ */
+export function extractLikelyErrors(
+  logText: string,
+  options: ExtractLikelyErrorsOptions = {}
+): string[] {
+  const { cwd, maxLines = 8, width = 100 } = options;
+  const text = logText.trim();
+  if (!text) return [];
+
+  const lines = text.split(/\r?\n/);
+
+  let bestIndex = -1;
+  let bestScore = Infinity;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const signatureRank = ERROR_SIGNATURES.findIndex((re) => re.test(line));
+    if (signatureRank === -1) continue;
+
+    const referencesProject =
+      (!!cwd && line.includes(cwd)) || /(^|[^\w])src[\\/]/.test(line);
+    // Lower score is better; a project reference strongly outranks signature order.
+    const score =
+      signatureRank - (referencesProject ? PROJECT_REFERENCE_BOOST : 0);
+    if (score < bestScore) {
+      bestScore = score;
+      bestIndex = i;
+    }
+  }
+
+  // Fallback: first N non-empty lines (previous formatErrorConsoleLog behavior).
+  if (bestIndex === -1) {
+    return reflowText(text, width)
+      .filter((line) => line.trim().length > 0)
+      .slice(0, maxLines);
+  }
+
+  // Return a small window around the best match (one line of lead-in for context).
+  const start = Math.max(0, bestIndex - 1);
+  const end = Math.min(lines.length, start + maxLines);
+  return reflowText(lines.slice(start, end).join('\n'), width);
+}

--- a/src/diagnostics/redact.test.ts
+++ b/src/diagnostics/redact.test.ts
@@ -25,8 +25,39 @@ describe('redactSecrets', () => {
     expect(redactSecrets(token)).toBe('[redacted]');
   });
 
-  it('leaves ordinary text and file paths intact', () => {
+  it('redacts PEM private key blocks', () => {
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nMIIabc\nDEFghi\n-----END RSA PRIVATE KEY-----';
+    const out = redactSecrets(`key:\n${pem}\ndone`);
+    expect(out).not.toContain('MIIabc');
+    expect(out).toContain('[redacted]');
+  });
+
+  it('redacts known provider token shapes', () => {
+    expect(redactSecrets('AKIAIOSFODNN7EXAMPLE')).toBe('[redacted]');
+    expect(redactSecrets('ghp_0123456789abcdefghijklmnopqrstuvwxyz')).toBe(
+      '[redacted]'
+    );
+    expect(redactSecrets('xoxb-123456789012-abcdefghijkl')).toBe('[redacted]');
+    expect(redactSecrets('AIzaSyA1234567890abcdefghijklmnopqrstuv')).toBe(
+      '[redacted]'
+    );
+  });
+
+  it('redacts credentials embedded in URLs', () => {
+    const out = redactSecrets(
+      'postgres://admin:s3cr3tpw@db.example.com:5432/x'
+    );
+    expect(out).not.toContain('s3cr3tpw');
+    expect(out).toContain('://[redacted]@db.example.com');
+  });
+
+  it('leaves ordinary text, file paths, and non-credential prose intact', () => {
     const text = 'Build failed at /Users/me/project/src/index.ts line 42';
     expect(redactSecrets(text)).toBe(text);
+    // "Token" is no longer treated as an auth scheme
+    expect(redactSecrets('Token expired at noon')).toBe(
+      'Token expired at noon'
+    );
   });
 });

--- a/src/diagnostics/redact.test.ts
+++ b/src/diagnostics/redact.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { redactSecrets } from './redact';
+
+describe('redactSecrets', () => {
+  it('redacts JWTs', () => {
+    const jwt =
+      'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c';
+    const out = redactSecrets(`token is ${jwt} ok`);
+    expect(out).not.toContain(jwt);
+    expect(out).toContain('[redacted]');
+  });
+
+  it('redacts sensitive key/value pairs', () => {
+    expect(redactSecrets('password="hunter2secret"')).not.toContain(
+      'hunter2secret'
+    );
+    expect(redactSecrets('"apiKey": "abcdef123456xyz"')).not.toContain(
+      'abcdef123456xyz'
+    );
+    expect(redactSecrets('token=supersecretvalue')).toContain('[redacted]');
+  });
+
+  it('redacts long opaque tokens', () => {
+    const token = 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0';
+    expect(redactSecrets(token)).toBe('[redacted]');
+  });
+
+  it('leaves ordinary text and file paths intact', () => {
+    const text = 'Build failed at /Users/me/project/src/index.ts line 42';
+    expect(redactSecrets(text)).toBe(text);
+  });
+});

--- a/src/diagnostics/redact.ts
+++ b/src/diagnostics/redact.ts
@@ -5,23 +5,43 @@ const REDACTED = '[redacted]';
  * diagnostics file. Log output (especially from auth / server paths) can contain
  * tokens or credentials, and the diagnostics file is intended to be shared.
  *
+ * Best-effort defence-in-depth — the primary protection is not capturing secrets
+ * in the first place (e.g. credential errors store field names, not values). This
+ * scrubs the one input we don't control: captured build/subprocess log tails.
+ *
  * Deliberately conservative about paths: the long-opaque-token pass excludes the
  * `/` separator so file paths (useful for diagnosis) are not eaten.
  */
 export function redactSecrets(input: string): string {
   let out = input;
 
-  // JWTs: header.payload.signature (base64url segments)
+  // PEM private key blocks (whole block, incl. RSA/EC/OPENSSH variants).
+  out = out.replace(
+    /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z]+ )?PRIVATE KEY-----/g,
+    REDACTED
+  );
+
+  // JWTs: header.payload.signature (base64url segments).
   out = out.replace(
     /eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]+/g,
     REDACTED
   );
 
-  // Authorization schemes: Bearer / Basic / Token <credential>
+  // Known provider token shapes — high signal, negligible false-positive risk.
+  out = out.replace(/\bAKIA[0-9A-Z]{16}\b/g, REDACTED); // AWS access key id
+  out = out.replace(/\bgh[pousr]_[A-Za-z0-9]{36,}\b/g, REDACTED); // GitHub tokens
+  out = out.replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, REDACTED); // Slack tokens
+  out = out.replace(/\bAIza[0-9A-Za-z_-]{35}\b/g, REDACTED); // Google API key
+
+  // Authorization schemes: `Bearer <credential>` / `Basic <credential>`.
+  // (No `Token` — it collides with ordinary prose like "Token expired".)
   out = out.replace(
-    /\b(Bearer|Basic|Token)\s+[A-Za-z0-9._~+/=-]+/gi,
+    /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi,
     (_match, scheme: string) => `${scheme} ${REDACTED}`
   );
+
+  // Credentials embedded in URLs: `scheme://user:pass@host`.
+  out = out.replace(/:\/\/[^/\s:@]+:[^/\s:@]+@/g, `://${REDACTED}@`);
 
   // Sensitive key/value pairs: `token: "…"`, `apiKey=…`, `"password": "…"`, etc.
   out = out.replace(
@@ -30,7 +50,7 @@ export function redactSecrets(input: string): string {
       `${prefix}${quote}${REDACTED}${quote}`
   );
 
-  // Long opaque tokens (base64/hex runs, no path separators so we keep file paths)
+  // Long opaque tokens (base64/hex runs, no path separators so we keep file paths).
   out = out.replace(/\b[A-Za-z0-9+_-]{40,}={0,2}\b/g, REDACTED);
 
   return out;

--- a/src/diagnostics/redact.ts
+++ b/src/diagnostics/redact.ts
@@ -1,0 +1,37 @@
+const REDACTED = '[redacted]';
+
+/**
+ * Scrub secret-looking strings from text before it is written to the
+ * diagnostics file. Log output (especially from auth / server paths) can contain
+ * tokens or credentials, and the diagnostics file is intended to be shared.
+ *
+ * Deliberately conservative about paths: the long-opaque-token pass excludes the
+ * `/` separator so file paths (useful for diagnosis) are not eaten.
+ */
+export function redactSecrets(input: string): string {
+  let out = input;
+
+  // JWTs: header.payload.signature (base64url segments)
+  out = out.replace(
+    /eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]+/g,
+    REDACTED
+  );
+
+  // Authorization schemes: Bearer / Basic / Token <credential>
+  out = out.replace(
+    /\b(Bearer|Basic|Token)\s+[A-Za-z0-9._~+/=-]+/gi,
+    (_match, scheme: string) => `${scheme} ${REDACTED}`
+  );
+
+  // Sensitive key/value pairs: `token: "…"`, `apiKey=…`, `"password": "…"`, etc.
+  out = out.replace(
+    /((?:authorization|auth|api[_-]?key|access[_-]?key|token|secret|password|passwd|pwd)["']?\s*[:=]\s*)(["']?)[^\s"',}]+(["']?)/gi,
+    (_match, prefix: string, quote: string) =>
+      `${prefix}${quote}${REDACTED}${quote}`
+  );
+
+  // Long opaque tokens (base64/hex runs, no path separators so we keep file paths)
+  out = out.replace(/\b[A-Za-z0-9+_-]{40,}={0,2}\b/g, REDACTED);
+
+  return out;
+}

--- a/src/exceptions/errors.test.ts
+++ b/src/exceptions/errors.test.ts
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PublisherError, BuildError, handleError } from './errors';
+
+describe('PublisherError', () => {
+  it('defaults code to the class name and stores options', () => {
+    const err = new BuildError('boom', {
+      logPaths: ['/x/error.log'],
+      hint: 'do x',
+      context: { a: 1 },
+    });
+    expect(err).toBeInstanceOf(PublisherError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('BuildError');
+    expect(err.code).toBe('BuildError');
+    expect(err.logPaths).toEqual(['/x/error.log']);
+    expect(err.hint).toBe('do x');
+    expect(err.context).toEqual({ a: 1 });
+  });
+
+  it('uses an explicit code when provided', () => {
+    expect(new BuildError('x', { code: 'BUILD_FAILED' }).code).toBe(
+      'BUILD_FAILED'
+    );
+  });
+
+  it('works with a message only (back-compatible)', () => {
+    const err = new BuildError('just a message');
+    expect(err.message).toBe('just a message');
+    expect(err.code).toBe('BuildError');
+    expect(err.hint).toBeUndefined();
+  });
+});
+
+describe('handleError', () => {
+  let exitSpy: any;
+  let errSpy: any;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('__exit__');
+    }) as never);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const output = () =>
+    errSpy.mock.calls.map((c: any[]) => String(c[0])).join('\n');
+
+  it('renders code, fix hint, and diagnostics pointer; hides the stack by default', () => {
+    const err = new BuildError('App failed to build', {
+      code: 'BUILD_FAILED',
+      hint: 'See the logs',
+    });
+    expect(() =>
+      handleError(err, {
+        command: 'upload',
+        diagnosticsPath: '/p/.graphics-kit/diagnostics/latest.md',
+      })
+    ).toThrow('__exit__');
+
+    const out = output();
+    expect(out).toContain('BUILD_FAILED');
+    expect(out).toContain('Fix:');
+    expect(out).toContain('See the logs');
+    expect(out).toContain('latest.md');
+    expect(out).not.toMatch(/\n\s+at /); // no stack frames
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('shows the stack when --verbose is set', () => {
+    const original = process.argv;
+    process.argv = [...original, '--verbose'];
+    try {
+      const err = new BuildError('App failed to build');
+      expect(() => handleError(err)).toThrow('__exit__');
+      expect(output()).toMatch(/\n\s+at /);
+    } finally {
+      process.argv = original;
+    }
+  });
+});

--- a/src/exceptions/errors.ts
+++ b/src/exceptions/errors.ts
@@ -1,125 +1,89 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import picocolors from 'picocolors';
+import fs from 'fs';
+import { extractLikelyErrors } from '../diagnostics/likelyError';
 
-export class HTTPError extends Error {
-  constructor(message: string) {
-    super(message);
+/**
+ * Structured context attached to a {@link PublisherError}.
+ *
+ * These fields let both a human reading the terminal and an AI diagnosing the
+ * failure start from targeted information rather than a stack trace that points
+ * into bundled `dist`.
+ */
+export interface PublisherErrorOptions {
+  /** Stable machine code, e.g. `'BUILD_FAILED'`. Defaults to the class name. */
+  code?: string;
+  /**
+   * For delegated/subprocess errors, the log files where the *real* error lives
+   * (e.g. the build subprocess's captured stderr), which the thrower's own
+   * stack does not describe.
+   */
+  logPaths?: string[];
+  /** One-sentence, human-readable remediation. */
+  hint?: string;
+  /** The offending value / allowed-list / HTTP status etc., captured before it goes out of scope. */
+  context?: Record<string, unknown>;
+  /** The underlying error, preserved for debugging. */
+  cause?: unknown;
+}
+
+/**
+ * Base class for all publisher errors. Carries machine-readable context
+ * ({@link PublisherErrorOptions}) so failures are self-describing.
+ *
+ * `command` is stamped at the CLI boundary (see `runCommand` in `src/cli.ts`),
+ * not at the throw site, so throw sites stay ignorant of CLI context.
+ */
+export class PublisherError extends Error {
+  code: string;
+  command?: string;
+  logPaths?: string[];
+  hint?: string;
+  context?: Record<string, unknown>;
+
+  constructor(message: string, options: PublisherErrorOptions = {}) {
+    super(
+      message,
+      options.cause !== undefined ? { cause: options.cause } : undefined
+    );
     this.name = this.constructor.name;
+    this.code = options.code ?? this.constructor.name;
+    if (options.logPaths) this.logPaths = options.logPaths;
+    if (options.hint) this.hint = options.hint;
+    if (options.context) this.context = options.context;
     Error.captureStackTrace(this, this.constructor);
   }
 }
 
-export class ServerError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class HTTPError extends PublisherError {}
 
-export class ConfigError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class ServerError extends PublisherError {}
 
-export class LocationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class ConfigError extends PublisherError {}
 
-export class BuildError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class LocationError extends PublisherError {}
 
-export class FileNotFoundError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class BuildError extends PublisherError {}
 
-export class FileSystemError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class FileNotFoundError extends PublisherError {}
 
-export class InvalidLocaleError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class FileSystemError extends PublisherError {}
 
-export class InvalidFileTypeError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class InvalidLocaleError extends PublisherError {}
 
-export class PackageMetadataError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class InvalidFileTypeError extends PublisherError {}
 
-export class PageMetadataError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class PackageMetadataError extends PublisherError {}
 
-export class PackageConfigError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class PageMetadataError extends PublisherError {}
 
-export class UserConfigError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class PackageConfigError extends PublisherError {}
 
-export class EditionArchiveError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class UserConfigError extends PublisherError {}
 
-export class ServerCredentialsError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = this.constructor.name;
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
+export class EditionArchiveError extends PublisherError {}
+
+export class ServerCredentialsError extends PublisherError {}
 
 const coalesceToError = (err: unknown) => {
   return (
@@ -129,22 +93,79 @@ const coalesceToError = (err: unknown) => {
     : new Error(JSON.stringify(err));
 };
 
+/** Show the full stack only when the user opts in — it points into bundled `dist`. */
+const isVerbose = () =>
+  process.argv.includes('--verbose') || !!process.env.DEBUG;
+
+const readLikelyCause = (logPaths: string[]): string[] => {
+  const combined = logPaths
+    .map((logPath) => {
+      try {
+        return fs.readFileSync(logPath, 'utf8');
+      } catch {
+        return '';
+      }
+    })
+    .join('\n');
+  return extractLikelyErrors(combined, { cwd: process.cwd() });
+};
+
+export interface HandleErrorOptions {
+  /** The CLI command that was running, for display. */
+  command?: string;
+  /** Path to the diagnostics file written for this failure, if any. */
+  diagnosticsPath?: string | null;
+}
+
 /**
- * Log errors and exit the current process
- * @param error
+ * Render an error to the terminal and exit the process.
+ *
+ * For a {@link PublisherError} this surfaces the code, a heuristic "likely cause"
+ * (for delegated errors, extracted from the captured logs), the remediation
+ * hint, and pointers to the logs + diagnostics file. The raw stack is hidden
+ * unless `--verbose` / `DEBUG` is set.
  */
-export const handleError = (e: unknown) => {
+export const handleError = (e: unknown, options: HandleErrorOptions = {}) => {
   const error = coalesceToError(e);
+  const isPublisherError = error instanceof PublisherError;
+
+  const code = isPublisherError ? ` ${picocolors.dim(`[${error.code}]`)}` : '';
   const prefix = picocolors.red(picocolors.bold('> Publisher ERROR:'));
-  if (error.message) {
-    console.error(`${prefix} ${error.message}\n`);
-    if (error.stack) {
-      console.error(
-        picocolors.gray(error.stack.split('\n').slice(1).join('\n'))
-      );
+  console.error(`${prefix}${code} ${error.message || String(error)}`);
+
+  // Likely cause — for delegated errors, extracted from the captured logs.
+  if (isPublisherError && error.logPaths?.length) {
+    const likely = readLikelyCause(error.logPaths);
+    if (likely.length) {
+      console.error(`\n${picocolors.bold('Likely cause:')}`);
+      for (const line of likely) console.error(picocolors.red(line));
     }
-  } else {
-    console.error(`${prefix} ${error}`);
   }
+
+  // Remediation hint.
+  if (isPublisherError && error.hint) {
+    console.error(`\n${picocolors.bold('Fix:')} ${error.hint}`);
+  }
+
+  // Pointers to logs + the prompt-ready diagnostics file.
+  const pointers: string[] = [];
+  if (isPublisherError && error.logPaths?.length) {
+    pointers.push(`Logs: ${error.logPaths.join(', ')}`);
+  }
+  if (options.diagnosticsPath) {
+    pointers.push(`Diagnostics: ${options.diagnosticsPath}`);
+  }
+  if (pointers.length) {
+    console.error('');
+    for (const pointer of pointers) console.error(picocolors.dim(pointer));
+  }
+
+  // Full stack only on opt-in.
+  if (isVerbose() && error.stack) {
+    console.error(
+      `\n${picocolors.gray(error.stack.split('\n').slice(1).join('\n'))}`
+    );
+  }
+
   process.exit(1);
 };

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -8,17 +8,27 @@ class Logs {
     return path.join(context.cwd, this.logDirName);
   }
 
+  /** Absolute path to the stderr log file. */
+  get errLogPath() {
+    return path.join(this.logDir, 'error.log');
+  }
+
+  /** Absolute path to the stdout log file. */
+  get outLogPath() {
+    return path.join(this.logDir, 'out.log');
+  }
+
   private write(filePath: string, logContents: string) {
     const prefix = `----- ${new Date().toISOString()} -----\n\n`;
     utils.fs.ensureWriteFile(filePath, prefix + logContents);
   }
 
   writeOutLog(logContents: string) {
-    this.write(path.join(this.logDir, 'out.log'), logContents);
+    this.write(this.outLogPath, logContents);
   }
 
   writeErrLog(logContents: string) {
-    this.write(path.join(this.logDir, 'error.log'), logContents);
+    this.write(this.errLogPath, logContents);
   }
 }
 

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,6 +1,60 @@
 import path from 'path';
+import fs from 'fs';
+import * as find from 'empathic/find';
+import ignore from 'ignore';
 import { context } from '../context';
 import { utils } from '@reuters-graphics/graphics-bin';
+import { note } from '@reuters-graphics/clack';
+import picocolors from 'picocolors';
+
+/** The publisher's working directory — logs and diagnostics live here. */
+export const GRAPHICS_KIT_DIR = '.graphics-kit/';
+
+/**
+ * Ensure `.graphics-kit/` is git-ignored so the logs and diagnostics we write
+ * there (which can contain build output) are never committed.
+ *
+ * Called wherever we first write into `.graphics-kit/`. Best-effort and idempotent:
+ * - Not a git repo → nothing to do.
+ * - Already ignored → nothing to do.
+ * - `.gitignore` exists but doesn't cover it → append the entry.
+ * - Git repo with no `.gitignore` → create one.
+ *
+ * Never throws — a failure here must not mask the caller's real work.
+ */
+export const ensureGraphicsKitIgnored = () => {
+  try {
+    const { cwd } = context;
+    if (!find.up('.git', { cwd })) return;
+
+    const entry = `# Reuters Graphics publisher working files\n${GRAPHICS_KIT_DIR}\n`;
+    const ignoreFile = find.up('.gitignore', { cwd });
+
+    if (!ignoreFile) {
+      fs.writeFileSync(path.join(cwd, '.gitignore'), entry);
+      note(
+        `Created ${picocolors.cyan('.gitignore')} ignoring ${picocolors.cyan(GRAPHICS_KIT_DIR)}.`,
+        'Updated .gitignore'
+      );
+      return;
+    }
+
+    const contents = fs.readFileSync(ignoreFile, 'utf8');
+    // `ignore().createFilter()` returns true for paths that are NOT ignored.
+    const notIgnored = ignore().add(contents).createFilter();
+    if (!notIgnored(path.join(GRAPHICS_KIT_DIR, 'probe'))) return; // already ignored
+
+    const separator =
+      contents.length === 0 || contents.endsWith('\n') ? '\n' : '\n\n';
+    fs.appendFileSync(ignoreFile, separator + entry);
+    note(
+      `Added ${picocolors.cyan(GRAPHICS_KIT_DIR)} to ${picocolors.cyan('.gitignore')}.`,
+      'Updated .gitignore'
+    );
+  } catch {
+    // Best-effort — never block the caller on gitignore housekeeping.
+  }
+};
 
 class Logs {
   logDirName = '.graphics-kit/logs/' as const;
@@ -19,6 +73,7 @@ class Logs {
   }
 
   private write(filePath: string, logContents: string) {
+    ensureGraphicsKitIgnored();
     const prefix = `----- ${new Date().toISOString()} -----\n\n`;
     utils.fs.ensureWriteFile(filePath, prefix + logContents);
   }

--- a/src/pack/archive/index.ts
+++ b/src/pack/archive/index.ts
@@ -90,7 +90,10 @@ export class Archive {
 
   async createOrUpdate() {
     if (!this.pack.serverClient)
-      throw new PackageMetadataError('Must create graphic pack first');
+      throw new PackageMetadataError('Must create graphic pack first', {
+        code: 'PACK_NOT_CREATED',
+        hint: 'Run the upload step (which creates the pack) before this operation.',
+      });
     const { serverClient } = this.pack;
     const metadata = await this.getMetadata();
     const zipPath = await this.packUp();

--- a/src/pack/edition/types/base.ts
+++ b/src/pack/edition/types/base.ts
@@ -40,11 +40,20 @@ export class Edition {
     this.archive.editions.push(this);
     if (!fs.existsSync(path))
       throw new FileSystemError(
-        `Local path for edition detected but not found on file system: ${path}`
+        `Local path for edition detected but not found on file system: ${path}`,
+        {
+          code: 'EDITION_PATH_NOT_FOUND',
+          context: { path, locale, mediaSlug },
+        }
       );
     if (!VALID_LOCALES.includes(locale))
       throw new InvalidLocaleError(
-        `Found invalid locale "${locale}" for edition at: ${this.path}`
+        `Found invalid locale "${locale}" for edition at: ${this.path}`,
+        {
+          code: 'INVALID_LOCALE',
+          hint: 'Use a supported locale code for this edition.',
+          context: { locale, validLocales: VALID_LOCALES },
+        }
       );
   }
 

--- a/src/pack/edition/types/interactive.ts
+++ b/src/pack/edition/types/interactive.ts
@@ -43,11 +43,19 @@ export class Interactive extends Edition {
       !this.pack.metadata.description
     )
       throw new PackageMetadataError(
-        'Must create or update graphic pack first'
+        'Must create or update graphic pack first',
+        {
+          code: 'PACK_METADATA_INCOMPLETE',
+          hint: 'Ensure the pack has an id, title, and description before uploading editions.',
+        }
       );
     if (!this.pack.serverClient)
       throw new PackageMetadataError(
-        'Must create or update graphic pack first'
+        'Must create or update graphic pack first',
+        {
+          code: 'PACK_NOT_CREATED',
+          hint: 'Run the upload step (which creates the pack) before this operation.',
+        }
       );
 
     const { serverClient } = this.pack;
@@ -177,7 +185,11 @@ export class Interactive extends Edition {
     const editionUrl = PKG.archive(this.archive.id).url;
     if (!editionUrl)
       throw new PackageMetadataError(
-        'Must get URL for interactive edition before writing manifest'
+        'Must get URL for interactive edition before writing manifest',
+        {
+          code: 'MISSING_EDITION_URL',
+          context: { archiveId: this.archive.id },
+        }
       );
 
     await this.makeStaticImage(archiveDir);

--- a/src/pack/edition/types/media-interactive.ts
+++ b/src/pack/edition/types/media-interactive.ts
@@ -44,7 +44,12 @@ export class MediaInteractive extends Edition {
 
     if (!ogUrl)
       throw new PageMetadataError(
-        `Missing canonical link element in file: ${path.relative(context.cwd, this.path)}`
+        `Missing canonical link element in file: ${path.relative(context.cwd, this.path)}`,
+        {
+          code: 'MISSING_CANONICAL_LINK',
+          hint: 'Add a <link rel="canonical"> tag to the page.',
+          context: { file: path.relative(context.cwd, this.path) },
+        }
       );
 
     const docContext = {
@@ -63,7 +68,12 @@ export class MediaInteractive extends Edition {
       const absDocPath = utils.path.absolute(docValue, context.cwd);
       if (!fs.existsSync(absDocPath))
         throw new FileNotFoundError(
-          `Could not find file "${docValue}" referenced in publisher.config.ts > archiveEditions.docs settings.`
+          `Could not find file "${docValue}" referenced in publisher.config.ts > archiveEditions.docs settings.`,
+          {
+            code: 'MISSING_ARCHIVE_DOC',
+            hint: 'Fix the path in your publisher config `archiveEditions.docs`, or add the missing file.',
+            context: { docValue, absDocPath },
+          }
         );
       const docString = mustache.render(
         fs.readFileSync(absDocPath, 'utf8'),

--- a/src/pack/edition/utils/archive.ts
+++ b/src/pack/edition/utils/archive.ts
@@ -37,7 +37,12 @@ class SrcArchive {
     const ignoreFile = find.up('.gitignore', { cwd });
     if (!ignoreFile)
       throw new FileNotFoundError(
-        'Error finding .gitignore in this project. One should be in the project root.'
+        'Error finding .gitignore in this project. One should be in the project root.',
+        {
+          code: 'MISSING_GITIGNORE',
+          hint: 'Add a .gitignore to your project root.',
+          context: { cwd },
+        }
       );
 
     const gitignoreFilter = ignore()
@@ -98,7 +103,16 @@ class SrcArchive {
         'Project zip too large'
       );
       throw new EditionArchiveError(
-        `Project archive is over ${MAX_ARCHIVE_MB_SIZE}MB limit.`
+        `Project archive is over ${MAX_ARCHIVE_MB_SIZE}MB limit.`,
+        {
+          code: 'ARCHIVE_TOO_LARGE',
+          hint: `Remove large files or add them to the \`archiveEditions.ignore\` setting in publisher.config.ts.`,
+          context: {
+            sizeMb: Number(fileSizeInMegabytes.toFixed(1)),
+            limitMb: MAX_ARCHIVE_MB_SIZE,
+            archivePath: this.archivePath,
+          },
+        }
       );
     }
 

--- a/src/pack/edition/utils/getPreviewImgPath.ts
+++ b/src/pack/edition/utils/getPreviewImgPath.ts
@@ -32,9 +32,17 @@ export const getPreviewImagePath = async (htmlPath: string) => {
   const { ogUrl, ogImage } = await getLocalHTMLPageMetadata(htmlPath);
 
   if (!ogImage)
-    throw new PageMetadataError(`No "og:image" tag found in ${htmlPath}`);
+    throw new PageMetadataError(`No "og:image" tag found in ${htmlPath}`, {
+      code: 'MISSING_OG_IMAGE',
+      hint: 'Add an <meta property="og:image"> tag to the page.',
+      context: { htmlPath },
+    });
   if (!ogUrl)
-    throw new PageMetadataError(`No canonical link found in ${htmlPath}`);
+    throw new PageMetadataError(`No canonical link found in ${htmlPath}`, {
+      code: 'MISSING_CANONICAL_LINK',
+      hint: 'Add a <link rel="canonical"> tag to the page.',
+      context: { htmlPath },
+    });
 
   const imgUrl = ogImage[0].url;
 
@@ -60,12 +68,25 @@ export const getPreviewImagePath = async (htmlPath: string) => {
 
   if (!VALID_IMAGE_FORMATS.includes(path.extname(pathToPreviewImage)))
     throw new InvalidFileTypeError(
-      `Invalid preview image type: ${path.basename(pathToPreviewImage)}`
+      `Invalid preview image type: ${path.basename(pathToPreviewImage)}`,
+      {
+        code: 'INVALID_PREVIEW_IMAGE_TYPE',
+        hint: 'Use a supported preview image format.',
+        context: {
+          previewImage: pathToPreviewImage,
+          allowed: VALID_IMAGE_FORMATS,
+        },
+      }
     );
 
   if (!fs.existsSync(pathToPreviewImage))
     throw new FileNotFoundError(
-      `Preview image detected in metadata but not found: ${pathToPreviewImage}`
+      `Preview image detected in metadata but not found: ${pathToPreviewImage}`,
+      {
+        code: 'PREVIEW_IMAGE_NOT_FOUND',
+        hint: 'Ensure the og:image referenced in your HTML exists in the build output.',
+        context: { previewImage: pathToPreviewImage, htmlPath },
+      }
     );
   return pathToPreviewImage;
 };

--- a/src/precheck/checkInvalidFiles.ts
+++ b/src/precheck/checkInvalidFiles.ts
@@ -17,7 +17,12 @@ export const checkInvalidfiles = () => {
 
   if (!ignoreFile)
     throw new FileNotFoundError(
-      'Error finding .gitignore in this project. One should be in the project root.'
+      'Error finding .gitignore in this project. One should be in the project root.',
+      {
+        code: 'MISSING_GITIGNORE',
+        hint: 'Add a .gitignore to your project root.',
+        context: { cwd },
+      }
     );
 
   const gitignoreFilter = ignore()
@@ -45,6 +50,10 @@ export const checkInvalidfiles = () => {
       'Invalid files found'
     );
 
-    throw new FileSystemError('Invalid files found');
+    throw new FileSystemError('Invalid files found', {
+      code: 'INVALID_PROJECT_FILES',
+      hint: 'Remove the listed files (e.g. stray .zip archives) and try again.',
+      context: { invalidFiles },
+    });
   }
 };

--- a/src/server/credentials.ts
+++ b/src/server/credentials.ts
@@ -19,8 +19,17 @@ type ServerCreds = v.InferInput<typeof ServerCredsSchema>;
 const validate = (creds: ServerCreds) => {
   try {
     v.parse(ServerCredsSchema, creds);
-  } catch {
-    throw new ServerCredentialsError('Invalid graphics server credentials');
+  } catch (cause) {
+    // Only field NAMES go in context — never the credential values.
+    const missingFields = Object.entries(creds ?? {})
+      .filter(([, value]) => !value)
+      .map(([key]) => key);
+    throw new ServerCredentialsError('Invalid graphics server credentials', {
+      code: 'INVALID_SERVER_CREDENTIALS',
+      hint: 'Check your username, password, and API key for the graphics server.',
+      context: { missingFields },
+      cause,
+    });
   }
   return creds;
 };
@@ -40,7 +49,12 @@ export const getServerCredentials = () => {
   );
   if (!fs.existsSync(credFilePath)) {
     throw new UserConfigError(
-      `Can't find graphics server credentials file ${picocolors.cyan('~/.reuters-graphics/graphics-server.json')}`
+      `Can't find graphics server credentials file ${picocolors.cyan('~/.reuters-graphics/graphics-server.json')}`,
+      {
+        code: 'MISSING_CREDENTIALS_FILE',
+        hint: 'Create the credentials file at ~/.reuters-graphics/graphics-server.json with your server username, password, and API key.',
+        context: { credFilePath },
+      }
     );
   }
   return validate(fs.readJsonSync(credFilePath));

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -16,27 +16,50 @@ axiosRetry(axios, {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const catchGraphicsServerError = (e: any) => {
+  const requestContext = {
+    status: e?.response?.status,
+    method: e?.request?.method,
+    url: e?.request?.url,
+  };
   // RNGS errors
   if (has(e, 'response.data.errors')) {
     const errorMessage = e.response.data.errors
       .map((e: { error_description: string }) => e.error_description)
       .join('; ');
-    return new ServerError(`Error(s): ${errorMessage}`);
+    return new ServerError(`Error(s): ${errorMessage}`, {
+      code: 'GRAPHICS_SERVER_ERROR',
+      context: requestContext,
+      cause: e,
+    });
   }
   if (has(e, 'response.data.error_description')) {
     const errorMessage = e.response.data.error_description;
-    return new ServerError(`Error: ${errorMessage}`);
+    return new ServerError(`Error: ${errorMessage}`, {
+      code: 'GRAPHICS_SERVER_ERROR',
+      context: requestContext,
+      cause: e,
+    });
   }
   if (has(e, 'errorMessage')) {
     const errorMessage = e.errorMessage;
-    return new ServerError(`Error: ${errorMessage}`);
+    return new ServerError(`Error: ${errorMessage}`, {
+      code: 'GRAPHICS_SERVER_ERROR',
+      context: requestContext,
+      cause: e,
+    });
   }
   // Axios error
   if (axios.isAxiosError(e)) {
     return new HTTPError(
       `${e.response?.status || 'UNKNOWN'} ${e.request.method} ERROR at ${
         e.request.url
-      }`
+      }`,
+      {
+        code: 'HTTP_ERROR',
+        context: requestContext,
+        hint: 'Check your network connection and that the graphics server is reachable.',
+        cause: e,
+      }
     );
   }
   return e;

--- a/src/server/token.ts
+++ b/src/server/token.ts
@@ -125,16 +125,24 @@ export class Token {
     try {
       const jwt = jwtDecode(token) as { rights: string[] };
       rights = jwt.rights;
-    } catch {
+    } catch (cause) {
       this._clearCachedTempToken();
       throw new ServerError(
-        "Invalid API token. Couldn't decode the provided token."
+        "Invalid API token. Couldn't decode the provided token.",
+        {
+          code: 'INVALID_API_TOKEN',
+          hint: 'Copy a fresh token from the graphics server portal and try again.',
+          cause,
+        }
       );
     }
 
     if (!rights) {
       this._clearCachedTempToken();
-      throw new ServerError('Invalid API token. Token has no rights.');
+      throw new ServerError('Invalid API token. Token has no rights.', {
+        code: 'API_TOKEN_NO_RIGHTS',
+        hint: 'Copy a fresh token from the graphics server portal and try again.',
+      });
     }
 
     /**
@@ -147,7 +155,12 @@ export class Token {
 
     if (throwOnInvalid) {
       throw new ServerError(
-        'Invalid API token. Token missing rights to publish to graphics server.'
+        'Invalid API token. Token missing rights to publish to graphics server.',
+        {
+          code: 'API_TOKEN_MISSING_GFX_RIGHTS',
+          hint: 'Your token lacks GFX_ publishing rights — request graphics-server access.',
+          context: { rights },
+        }
       );
     }
 

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -32,6 +32,11 @@ export const validateOrThrow = <T extends GenericSchema, V>(
     return result.output;
   } else {
     const errorMsgs = result.issues.map((issue) => issue.message).join(' ');
-    throw new PackageMetadataError(errorMsgs || 'Data is invalid');
+    throw new PackageMetadataError(errorMsgs || 'Data is invalid', {
+      code: 'INVALID_PACK_METADATA',
+      context: {
+        issues: result.issues.map((issue) => issue.message),
+      },
+    });
   }
 };


### PR DESCRIPTION
Part **1 of 2** for #141 — the non-AI foundation (Layers 1 & 2 + baseline output). Part 2 (the Claude Code handoff) will follow.

## What changed

### Layer 1 — structured errors
- New `PublisherError` base class carrying `code`, `command`, `logPaths`, `hint`, and structured `context`. The 15 existing error classes now extend it (message-only construction still works — options are additive).
- The CLI **command name is stamped onto the error at the boundary** (`runCommand('upload', …)`), not at throw sites.
- **Enrichment sweep** across every conscious custom `throw`: `logPaths`+`hint` for delegated errors (build, HTTP), `hint`+`context` (offending value / allowed-list / status) for rule/validation errors. Credential errors put only field *names* in context, never values.

### Layer 2 — diagnostics file
- New `src/diagnostics` module. `writeDiagnostics()` writes a prompt-ready markdown bundle to `.graphics-kit/diagnostics/latest.md` (+ a timestamped copy). Best-effort: any failure returns `null` rather than masking the real error.
- **Git-ignore handling — ensure, don't skip.** Rather than silently skipping the write when the path isn't ignored, we ensure `.graphics-kit/` is git-ignored the first time we write there (append to `.gitignore`, or create one), then always write. This runs from `Logs.write` too, so the build logs — already written to `.graphics-kit/` unconditionally — are covered by the same guarantee. Not a git repo → write with no `.gitignore` edit. `ensureGraphicsKitIgnored()` is idempotent and never throws.
- **Secret redaction** on the whole payload — best-effort defence-in-depth over log tails (the primary protection is not capturing secrets at the source). Covers PEM private-key blocks, JWTs, provider token shapes (AWS / GitHub / Slack / Google), `Bearer`/`Basic` schemes, URL-embedded credentials (`scheme://user:pass@host`), sensitive `key=value` pairs, and a generic long-token catch-all — deliberately preserving file paths.

### Baseline output
- `handleError` overhauled: `> Publisher ERROR [CODE]: …` → **Likely cause** → **Fix** hint → **Pointers** (logs + diagnostics file). The raw `dist` stack is now hidden behind `--verbose` / `DEBUG`.
- The **likely-cause heuristic** (`extractLikelyErrors`, replacing `formatErrorConsoleLog`) is tuned for the stack the publisher actually builds — `vite build` over SvelteKit 2 / Svelte 5 / sass (the bluprint template). Signatures are ordered specific → generic (vite-plugin-svelte, SassError, Rollup/esbuild resolve, prerender, …); it prefers lines referencing your own code (`src/`, `.svelte`, `file:line`) and ignores `node_modules` noise.
- `build/index.ts` simplified — `BuildError` carries the log paths and `handleError` renders; the duplicate note block is gone.

## Tests
New: `redact`, `likelyError`, `writeDiagnostics` (mock-fs: already-ignored → no edit / not-ignored → append / no-.gitignore → create / non-git → write), and `PublisherError` + `handleError` rendering (incl. `--verbose` stack).

## Verification
- `tsc --noEmit` clean
- **165/165 tests pass**
- `pnpm build` succeeds
- eslint clean

A `minor` changeset is included.

## Heads-up for reviewers
A normal `graphics-publisher` run may now append `.graphics-kit/` to the project's `.gitignore` on first use (with a printed note) — the intended trade-off of the "ensure ignored" approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
