### PR TITLE
feat: Claude Code handoff on failure (#141 part 2)

### DIFF
--- a/.changeset/ai-handoff.md
+++ b/.changeset/ai-handoff.md
@@ -1,0 +1,5 @@
+---
+'@reuters-graphics/graphics-kit-publisher': minor
+---
+
+Add the Claude Code handoff (issue #141, part 2 of 2). When a command fails in an interactive terminal, the publisher now offers to diagnose it with Claude Code — either opening the VSCode extension (chat next to your code, via a `vscode://` deep-link pre-filled with the diagnostics file) or running a one-shot `claude -p` in the terminal. Availability is detected (VSCode integrated terminal, `claude` on PATH), not credentials — authentication is however you've configured Claude Code. A new `graphics-publisher diagnose` command re-opens the handoff against the last failure without re-running the command, and a `publisher.config.ts` `ai: 'prompt' | 'off'` setting (plus `--no-ai`) controls the automatic prompt. Skipped in CI / non-TTY.

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ dist
 
 dist/
 .size-snapshot.json
+.claude/

--- a/docs/content/docs/Config/ai.mdx
+++ b/docs/content/docs/Config/ai.mdx
@@ -1,0 +1,59 @@
+---
+title: AI
+sidebar:
+  order: 17
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Controls whether the publisher offers an AI diagnosis when a command fails.
+
+## ai
+
+- **Type:**
+  ```typescript
+  'prompt' | 'off';
+  ```
+- **Default:**
+  ```typescript
+  'prompt';
+  ```
+
+When a command fails, the publisher writes a diagnostics file (the error, the
+build logs, and pointers to the relevant rules) to
+`.graphics-kit/diagnostics/latest.md` and, when this is set to `'prompt'`, offers
+to hand it off to [Claude Code](https://claude.com/claude-code) to diagnose:
+
+- **Open a Claude Code session** — opens the Claude Code VSCode extension in a
+  chat next to your code, pre-filled with the diagnostics (you review and press
+  Enter).
+- **Ask Claude what went wrong** — runs a one-shot diagnosis in your terminal.
+
+Set it to `'off'` to never show the prompt.
+
+```typescript
+// publisher.config.ts
+import { defineConfig } from '@reuters-graphics/graphics-kit-publisher';
+
+export default defineConfig({
+  ai: 'prompt',
+});
+```
+
+<Aside>
+The prompt only appears in an interactive terminal — it's skipped in CI. It's
+also skipped for the run if you pass `--no-ai`, e.g. `graphics-publisher upload
+--no-ai`.
+
+The publisher never handles authentication — it uses however you've already
+configured Claude Code (the VSCode extension option is offered when you're in a
+VSCode terminal; the terminal option when the `claude` CLI is on your `PATH`). We
+recommend installing the Claude Code VSCode extension.
+</Aside>
+
+<Aside type="tip">
+Missed the prompt, or want to look into a failure later without re-running a slow
+command? Run
+[`graphics-publisher diagnose`](/graphics-kit-publisher/commands/#diagnose) to
+re-open the diagnosis of the last command that failed.
+</Aside>

--- a/docs/content/docs/Notes/ai-in-the-loop.mdx
+++ b/docs/content/docs/Notes/ai-in-the-loop.mdx
@@ -5,18 +5,18 @@ sidebar:
   order: 102
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-As of 3.4.0, when a command fails, you're one keystroke away from having AI diagnose it — inside your project, with all the context it needs.
+As of 3.4.0, when a publisher command like `upload` or `preview` fails, you're one keystroke away from having AI diagnose what went wrong — inside your project, with all the context it needs.
 
 ## When something breaks
 
-Uploads and builds fail. Usually it's a real bug in your code, buried in a wall of build output that's hard to read and easy to misjudge.
+Uploads and builds sometimes fail. Usually it's a real bug in your code, buried in a wall of build output that's hard to read and easy to misjudge.
 
-Now, when a publisher command fails, we hand the problem to [Claude Code](https://claude.com/claude-code). The publisher writes a diagnostics file — the error, the likely cause pulled from your build logs, and pointers to the publisher's own rules — then offers to open it:
+Now, when a publisher command fails, we hand the problem to [Claude Code](https://claude.com/claude-code). The publisher writes a diagnostics file — the error, the likely cause pulled from your build logs and pointers to the publisher's own rules — then offers two ways you can use it with AI:
 
-- **Open a Claude Code session** — the VSCode extension opens a chat right next to your code, pre-filled and ready. It can read your project, find the real cause, and propose a fix.
-- **Ask Claude what went wrong** — a quick, read-only diagnosis in your terminal.
+- **Open a Claude Code session:** The VSCode extension opens a chat right next to your code, pre-filled and ready. It can read your project files and the error diagnostics, find the real cause and propose a fix in the chat. (And it won't edit files until you confirm you want to.)
+- **Ask Claude what went wrong:** Sends the error diagnostics to Claude in your terminal and prints back a quick, read-only synopsis of what the likeliest cause is.
 
 No copying stack traces into a chat window. No guessing which log line matters. The agent starts with everything the publisher already knows about the failure, scoped to _your_ project — not generic advice.
 
@@ -24,10 +24,23 @@ No copying stack traces into a chat window. No guessing which log line matters. 
 
 The prompt appears automatically the next time a command fails in your terminal. 
 
-Missed it, or don't want to re-run a slow build just to look again? Run [`graphics-publisher diagnose`](/graphics-kit-publisher/commands/#diagnose) to re-open the last one.
+Missed it, or don't want to re-run a slow build just to look again? You can run the new [`diagnose`](/graphics-kit-publisher/commands/#diagnose) command, which will read the error diagnostics from your last failed attempt.
+
+<Tabs>
+  <TabItem label="CLI" icon="setting">
+    ```console
+    pnpm graphics-publisher diagnose
+    ```
+  </TabItem>
+  <TabItem label="Graphics kit" icon="laptop">
+    ```console
+    pnpm diagnose
+    ```
+  </TabItem>
+</Tabs>
 
 <Aside>
-The publisher doesn't handle authenticating Claude — it assumes you've already done that yourself. Read more about our recommended setup for the Claude Code VSCode extension in our [Notion docs](https://app.notion.com/p/Setting-up-Claude-for-VSCode-359e5f6c99bc801c8494de7ea3f07cbe).
+The publisher **does not** handle setting up or authenticating Claude — it assumes you've already done that yourself. Read more about our recommended setup for Claude Code and the VSCode extension in our [Notion docs](https://app.notion.com/p/Setting-up-Claude-for-VSCode-359e5f6c99bc801c8494de7ea3f07cbe).
 </Aside>
 
 This is the first step of bringing AI into the publishing process — a small one, aimed at the moment it's most useful: when you're stuck. More to come.

--- a/docs/content/docs/Notes/ai-in-the-loop.mdx
+++ b/docs/content/docs/Notes/ai-in-the-loop.mdx
@@ -1,0 +1,33 @@
+---
+title: AI in the loop (3.4.0)
+sidebar:
+  badge: New
+  order: 102
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+As of 3.4.0, when a command fails, you're one keystroke away from having AI diagnose it — inside your project, with all the context it needs.
+
+## When something breaks
+
+Uploads and builds fail. Usually it's a real bug in your code, buried in a wall of build output that's hard to read and easy to misjudge.
+
+Now, when a publisher command fails, we hand the problem to [Claude Code](https://claude.com/claude-code). The publisher writes a diagnostics file — the error, the likely cause pulled from your build logs, and pointers to the publisher's own rules — then offers to open it:
+
+- **Open a Claude Code session** — the VSCode extension opens a chat right next to your code, pre-filled and ready. It can read your project, find the real cause, and propose a fix.
+- **Ask Claude what went wrong** — a quick, read-only diagnosis in your terminal.
+
+No copying stack traces into a chat window. No guessing which log line matters. The agent starts with everything the publisher already knows about the failure, scoped to _your_ project — not generic advice.
+
+## It's already on
+
+The prompt appears automatically the next time a command fails in your terminal. Missed it, or don't want to re-run a slow build just to look again? Run [`graphics-publisher diagnose`](/graphics-kit-publisher/commands/#diagnose) to re-open the last one.
+
+<Aside>
+Not into it? Set [`ai: 'off'`](/graphics-kit-publisher/config/ai/) in your `publisher.config.ts`, or pass `--no-ai` on any command. The prompt never shows in CI.
+
+The publisher doesn't touch authentication — it uses however you've set up Claude Code. We recommend the [Claude Code VSCode extension](https://claude.com/claude-code).
+</Aside>
+
+This is the first step of bringing AI into the publishing process — a small one, aimed at the moment it's most useful: when you're stuck. More to come.

--- a/docs/content/docs/Notes/ai-in-the-loop.mdx
+++ b/docs/content/docs/Notes/ai-in-the-loop.mdx
@@ -22,12 +22,12 @@ No copying stack traces into a chat window. No guessing which log line matters. 
 
 ## It's already on
 
-The prompt appears automatically the next time a command fails in your terminal. Missed it, or don't want to re-run a slow build just to look again? Run [`graphics-publisher diagnose`](/graphics-kit-publisher/commands/#diagnose) to re-open the last one.
+The prompt appears automatically the next time a command fails in your terminal. 
+
+Missed it, or don't want to re-run a slow build just to look again? Run [`graphics-publisher diagnose`](/graphics-kit-publisher/commands/#diagnose) to re-open the last one.
 
 <Aside>
-Not into it? Set [`ai: 'off'`](/graphics-kit-publisher/config/ai/) in your `publisher.config.ts`, or pass `--no-ai` on any command. The prompt never shows in CI.
-
-The publisher doesn't touch authentication — it uses however you've set up Claude Code. We recommend the [Claude Code VSCode extension](https://claude.com/claude-code).
+The publisher doesn't handle authenticating Claude — it assumes you've already done that yourself. Read more about our recommended setup for the Claude Code VSCode extension in our [Notion docs](https://app.notion.com/p/Setting-up-Claude-for-VSCode-359e5f6c99bc801c8494de7ea3f07cbe).
 </Aside>
 
 This is the first step of bringing AI into the publishing process — a small one, aimed at the moment it's most useful: when you're stuck. More to come.

--- a/docs/content/docs/Notes/announcing-3-0.mdx
+++ b/docs/content/docs/Notes/announcing-3-0.mdx
@@ -1,7 +1,6 @@
 ---
 title: Announcing 3.0
 sidebar:
-  badge: New
   order: 101
 ---
 

--- a/docs/content/docs/commands.mdx
+++ b/docs/content/docs/commands.mdx
@@ -107,3 +107,17 @@ pnpm graphics-publisher delete
 <Aside>
 Projects that have been published in the graphics server **cannot** be deleted.
 </Aside>
+
+## Diagnose
+
+Re-open an AI diagnosis of the last command that failed. Handy when you dismissed the prompt, or want to look into a failure without re-running a slow command like a build.
+
+```console
+pnpm graphics-publisher diagnose
+```
+
+This reuses the diagnostics file written to `.graphics-kit/diagnostics/latest.md` on the last failure and offers the same [Claude Code handoff](/graphics-kit-publisher/config/ai/). See the [`ai`](/graphics-kit-publisher/config/ai/) config option for what the handoff does and how to turn it off.
+
+<Aside>
+If nothing has failed yet, there's no diagnostics file to open — run a command that fails first.
+</Aside>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,9 @@
 import sade from 'sade';
 import { version } from '../package.json';
 import { GraphicsKitPublisher } from '.';
-import { handleError, PublisherError } from './exceptions/errors';
+import { renderError, PublisherError } from './exceptions/errors';
 import { writeDiagnostics } from './diagnostics';
+import { offerDiagnosisHandoff } from './diagnostics/handoff';
 
 const prog = sade('graphics-publisher');
 
@@ -31,7 +32,10 @@ const runCommand = async (command: string, action: () => Promise<void>) => {
     // Stamp the command onto the error at the boundary (throw sites don't know it).
     if (error instanceof PublisherError) error.command = command;
     const diagnosticsPath = writeDiagnostics(error, command);
-    handleError(error, { command, diagnosticsPath });
+    renderError(error, { command, diagnosticsPath });
+    // Offer the Claude Code handoff after the error is shown, before we exit.
+    await offerDiagnosisHandoff({ diagnosticsPath, command });
+    exitCleanly(1);
   }
 };
 
@@ -91,6 +95,13 @@ prog
   .command('delete')
   .action(() =>
     runCommand('delete', () => new GraphicsKitPublisher().delete())
+  );
+
+prog
+  .command('diagnose')
+  .describe('Re-open an AI diagnosis of the last command that failed')
+  .action(() =>
+    runCommand('diagnose', () => new GraphicsKitPublisher().diagnose())
   );
 
 prog.parse(process.argv);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -73,4 +73,5 @@ export const defaultConfig: Config = {
       '<script type="text/javascript" src="//graphics.thomsonreuters.com/pym.min.js"></script>',
   },
   publishingLocations: [],
+  ai: 'prompt',
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -235,6 +235,11 @@ export type Config = {
   archiveEditions: ArchiveEditions;
   embedTemplate: EmbedTemplate;
   publishingLocations: PublishingLocations;
+  /**
+   * When a command fails, whether to offer an AI diagnosis handoff to Claude
+   * Code. `'prompt'` (default) asks interactively; `'off'` disables it.
+   */
+  ai: 'prompt' | 'off';
 };
 
 type PartialDeep<K> = {

--- a/src/config/validate.test.ts
+++ b/src/config/validate.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { validateConfig } from './validate';
+import { defaultConfig } from './index';
+import { ConfigError } from '../exceptions/errors';
+
+describe('validateConfig — ai key', () => {
+  it('defaults to "prompt"', () => {
+    expect(defaultConfig.ai).toBe('prompt');
+  });
+
+  it('accepts "prompt" and "off"', () => {
+    expect(() =>
+      validateConfig({ ...defaultConfig, ai: 'prompt' })
+    ).not.toThrow();
+    expect(() => validateConfig({ ...defaultConfig, ai: 'off' })).not.toThrow();
+  });
+
+  it('rejects any other value', () => {
+    expect(() =>
+      // @ts-expect-error — intentionally invalid value
+      validateConfig({ ...defaultConfig, ai: 'sometimes' })
+    ).toThrow(ConfigError);
+  });
+});

--- a/src/config/validate.ts
+++ b/src/config/validate.ts
@@ -108,6 +108,7 @@ const ConfigSchema = v.required(
         ),
       })
     ),
+    ai: v.union([v.literal('prompt'), v.literal('off')]),
   })
 );
 

--- a/src/diagnostics/handoff.test.ts
+++ b/src/diagnostics/handoff.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import mockFs from 'mock-fs';
+import {
+  isAiEnabled,
+  detectSurfaces,
+  buildPointer,
+  buildExtensionUrl,
+  isClaudeOnPath,
+} from './handoff';
+
+describe('isAiEnabled', () => {
+  it('is enabled by default (config "prompt", no flag)', () => {
+    expect(isAiEnabled({ configAi: 'prompt', argv: [] })).toBe(true);
+  });
+
+  it('is disabled by --no-ai', () => {
+    expect(isAiEnabled({ configAi: 'prompt', argv: ['--no-ai'] })).toBe(false);
+  });
+
+  it('is disabled by ai: "off" config', () => {
+    expect(isAiEnabled({ configAi: 'off', argv: [] })).toBe(false);
+  });
+});
+
+describe('detectSurfaces', () => {
+  it('offers the extension only in a VSCode integrated terminal', () => {
+    expect(
+      detectSurfaces({ termProgram: 'vscode', claudeOnPath: false }).extension
+    ).toBe(true);
+    expect(
+      detectSurfaces({ termProgram: 'Apple_Terminal', claudeOnPath: false })
+        .extension
+    ).toBe(false);
+  });
+
+  it('offers the terminal only when claude is on PATH', () => {
+    expect(
+      detectSurfaces({ termProgram: '', claudeOnPath: true }).terminal
+    ).toBe(true);
+    expect(
+      detectSurfaces({ termProgram: '', claudeOnPath: false }).terminal
+    ).toBe(false);
+  });
+});
+
+describe('buildPointer', () => {
+  it('names the command when present', () => {
+    expect(buildPointer('/p/latest.md', 'upload')).toBe(
+      'Read /p/latest.md and diagnose the "upload" failure.'
+    );
+  });
+
+  it('omits the command when absent', () => {
+    expect(buildPointer('/p/latest.md')).toBe(
+      'Read /p/latest.md and diagnose the failure.'
+    );
+  });
+});
+
+describe('buildExtensionUrl', () => {
+  it('builds a url-encoded vscode deep-link', () => {
+    const url = buildExtensionUrl('Read /p/latest.md and diagnose.');
+    expect(url.startsWith('vscode://anthropic.claude-code/open?prompt=')).toBe(
+      true
+    );
+    expect(url).toContain('%2Fp%2Flatest.md'); // path is encoded
+    expect(url).not.toContain(' '); // spaces encoded
+  });
+});
+
+describe('isClaudeOnPath', () => {
+  const origPath = process.env.PATH;
+  afterEach(() => {
+    mockFs.restore();
+    process.env.PATH = origPath;
+  });
+
+  it('is true when an executable claude is on PATH', () => {
+    process.env.PATH = '/fake/bin';
+    mockFs({ '/fake/bin/claude': mockFs.file({ mode: 0o755, content: '' }) });
+    expect(isClaudeOnPath()).toBe(true);
+  });
+
+  it('is false when claude is not on PATH', () => {
+    process.env.PATH = '/fake/bin';
+    mockFs({ '/fake/bin/other': mockFs.file({ mode: 0o755, content: '' }) });
+    expect(isClaudeOnPath()).toBe(false);
+  });
+});

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -1,0 +1,186 @@
+import path from 'path';
+import fs from 'fs';
+import { spawn } from 'node:child_process';
+import { select, isCancel } from '@clack/prompts';
+import { note } from '@reuters-graphics/clack';
+import picocolors from 'picocolors';
+import open from 'open';
+import { utils } from '@reuters-graphics/graphics-bin';
+import { context } from '../context';
+
+export interface HandoffOptions {
+  /** Absolute path to the diagnostics file, or null if none was written. */
+  diagnosticsPath: string | null;
+  /** The command that failed, for the prompt text. */
+  command?: string;
+  /**
+   * Bypass the `ai: 'off'` / `--no-ai` gate. Used by the explicit `diagnose`
+   * command — those settings govern the *automatic* post-failure prompt, not a
+   * deliberate request. Interactivity and surface availability are still checked.
+   */
+  force?: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/* Pure helpers (unit-tested)                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Whether the AI handoff is enabled. Disabled by `--no-ai` or `ai: 'off'` config.
+ */
+export const isAiEnabled = (
+  opts: { configAi?: string; argv?: string[] } = {}
+): boolean => {
+  const argv = opts.argv ?? process.argv;
+  if (argv.includes('--no-ai')) return false;
+  const configAi = opts.configAi ?? context.config.ai;
+  return configAi !== 'off';
+};
+
+export interface Surfaces {
+  /** VSCode extension deep-link is viable (we're in an integrated terminal). */
+  extension: boolean;
+  /** `claude` CLI is on PATH. */
+  terminal: boolean;
+}
+
+/**
+ * Which Claude Code surfaces are available — availability only, not credentials.
+ */
+export const detectSurfaces = (
+  opts: { termProgram?: string; claudeOnPath?: boolean } = {}
+): Surfaces => {
+  const termProgram = opts.termProgram ?? process.env.TERM_PROGRAM;
+  const claudeOnPath = opts.claudeOnPath ?? isClaudeOnPath();
+  return { extension: termProgram === 'vscode', terminal: claudeOnPath };
+};
+
+/** The short prompt handed to Claude — points at the file, never inlines it. */
+export const buildPointer = (
+  diagnosticsPath: string,
+  command?: string
+): string =>
+  `Read ${diagnosticsPath} and diagnose the ${command ? `"${command}" ` : ''}failure.`;
+
+/** The VSCode extension deep-link that pre-fills (but does not submit) the prompt. */
+export const buildExtensionUrl = (pointer: string): string =>
+  `vscode://anthropic.claude-code/open?prompt=${encodeURIComponent(pointer)}`;
+
+/**
+ * Resolve whether a real `claude` executable is on PATH. A shell *alias* is not
+ * found — correct, since `spawn` can't use aliases either.
+ */
+export const isClaudeOnPath = (): boolean => {
+  const envPath = process.env.PATH;
+  if (!envPath) return false;
+  const extensions =
+    process.platform === 'win32' ?
+      (process.env.PATHEXT ?? '.EXE;.CMD;.BAT').split(';')
+    : [''];
+  for (const dir of envPath.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of extensions) {
+      try {
+        fs.accessSync(path.join(dir, `claude${ext}`), fs.constants.X_OK);
+        return true;
+      } catch {
+        // not in this dir
+      }
+    }
+  }
+  return false;
+};
+
+/* ------------------------------------------------------------------ */
+/* Interactive handoff                                                 */
+/* ------------------------------------------------------------------ */
+
+const isInteractive = (): boolean =>
+  !utils.environment.isCiEnvironment() &&
+  !!process.stdout.isTTY &&
+  !!process.stdin.isTTY;
+
+/** Run a one-shot `claude -p` diagnosis, streaming to the terminal. Never rejects. */
+const runTerminalDiagnosis = (pointer: string): Promise<void> =>
+  new Promise((resolve) => {
+    const child = spawn('claude', ['-p', pointer, '--output-format', 'text'], {
+      cwd: context.cwd,
+      stdio: 'inherit',
+    });
+    child.on('close', () => resolve());
+    child.on('error', () => resolve());
+  });
+
+/**
+ * After a failure, offer to hand the diagnostics file off to Claude Code — the
+ * VSCode extension (chat next to the code) or a one-shot `claude -p` in the
+ * terminal. Best-effort and never throws; returns without prompting when a
+ * handoff isn't possible (disabled, non-interactive, or nothing available).
+ */
+export const offerDiagnosisHandoff = async ({
+  diagnosticsPath,
+  command,
+  force = false,
+}: HandoffOptions): Promise<void> => {
+  try {
+    if (!diagnosticsPath || !isInteractive()) return;
+    if (!force && !isAiEnabled()) return;
+
+    const surfaces = detectSurfaces();
+    const pointer = buildPointer(diagnosticsPath, command);
+    const copyPasteNote = () =>
+      note(
+        `Diagnose later with:\n${picocolors.cyan(`claude "$(cat ${diagnosticsPath})"`)}`,
+        'AI diagnosis'
+      );
+
+    if (!surfaces.extension && !surfaces.terminal) {
+      copyPasteNote();
+      return;
+    }
+
+    const options: { value: string; label: string; hint?: string }[] = [];
+    if (surfaces.extension)
+      options.push({
+        value: 'extension',
+        label: 'Open a Claude Code session to diagnose & fix it',
+        hint: 'VSCode extension',
+      });
+    if (surfaces.terminal)
+      options.push({
+        value: 'terminal',
+        label: 'Ask Claude what went wrong',
+        hint: 'claude in terminal',
+      });
+    options.push({ value: 'no', label: 'No thanks' });
+
+    const choice = await select({
+      message: `Your "${command ?? 'command'}" command failed. Diagnose it with AI?`,
+      options,
+    });
+
+    if (isCancel(choice) || choice === 'no') {
+      copyPasteNote();
+      return;
+    }
+
+    if (choice === 'extension') {
+      try {
+        await open(buildExtensionUrl(pointer));
+        note(
+          'Opening Claude Code in VSCode — review the pre-filled prompt and press Enter.',
+          'AI diagnosis'
+        );
+      } catch {
+        copyPasteNote();
+      }
+      return;
+    }
+
+    if (choice === 'terminal') {
+      await runTerminalDiagnosis(pointer);
+    }
+  } catch {
+    // Never let the handoff mask the original failure.
+  }
+};

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -127,6 +127,10 @@ const buildContent = (error: unknown, command?: string): string => {
   return lines.join('\n');
 };
 
+/** Absolute path to the stable `latest.md` diagnostics file for this project. */
+export const latestDiagnosticsPath = (): string =>
+  path.join(context.cwd, DIAGNOSTICS_DIR, 'latest.md');
+
 /**
  * Write a prompt-ready diagnostics markdown file for a failed command. Secrets
  * are redacted, and `.graphics-kit/` is ensured git-ignored first so the file is
@@ -146,7 +150,7 @@ export const writeDiagnostics = (
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const content = redactSecrets(buildContent(error, command));
     const absTimestamped = path.join(cwd, DIAGNOSTICS_DIR, `${timestamp}.md`);
-    const absLatest = path.join(cwd, DIAGNOSTICS_DIR, 'latest.md');
+    const absLatest = latestDiagnosticsPath();
 
     utils.fs.ensureWriteFile(absTimestamped, content);
     utils.fs.ensureWriteFile(absLatest, content);

--- a/src/exceptions/errors.test.ts
+++ b/src/exceptions/errors.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PublisherError, BuildError, handleError } from './errors';
+import { PublisherError, BuildError, handleError, renderError } from './errors';
 
 describe('PublisherError', () => {
   it('defaults code to the class name and stores options', () => {
@@ -69,6 +69,16 @@ describe('handleError', () => {
     expect(out).toContain('latest.md');
     expect(out).not.toMatch(/\n\s+at /); // no stack frames
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('renderError renders WITHOUT exiting', () => {
+    const err = new BuildError('App failed to build', {
+      code: 'BUILD_FAILED',
+      hint: 'See the logs',
+    });
+    renderError(err, { command: 'upload' });
+    expect(output()).toContain('BUILD_FAILED');
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('shows the stack when --verbose is set', () => {

--- a/src/exceptions/errors.ts
+++ b/src/exceptions/errors.ts
@@ -118,14 +118,17 @@ export interface HandleErrorOptions {
 }
 
 /**
- * Render an error to the terminal and exit the process.
+ * Render an error to the terminal — WITHOUT exiting.
  *
  * For a {@link PublisherError} this surfaces the code, a heuristic "likely cause"
  * (for delegated errors, extracted from the captured logs), the remediation
  * hint, and pointers to the logs + diagnostics file. The raw stack is hidden
  * unless `--verbose` / `DEBUG` is set.
+ *
+ * Split from {@link handleError} so an interactive step (e.g. the Claude Code
+ * handoff) can run after the error is shown but before the process exits.
  */
-export const handleError = (e: unknown, options: HandleErrorOptions = {}) => {
+export const renderError = (e: unknown, options: HandleErrorOptions = {}) => {
   const error = coalesceToError(e);
   const isPublisherError = error instanceof PublisherError;
 
@@ -166,6 +169,12 @@ export const handleError = (e: unknown, options: HandleErrorOptions = {}) => {
       `\n${picocolors.gray(error.stack.split('\n').slice(1).join('\n'))}`
     );
   }
+};
 
+/**
+ * Render an error and exit the process with code 1.
+ */
+export const handleError = (e: unknown, options: HandleErrorOptions = {}) => {
+  renderError(e, options);
   process.exit(1);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@ import { Pack } from './pack';
 import { precheck } from './precheck';
 import { log } from '@clack/prompts';
 import picocolors from 'picocolors';
+import fs from 'fs';
+import { latestDiagnosticsPath } from './diagnostics';
+import { offerDiagnosisHandoff } from './diagnostics/handoff';
+import { FileNotFoundError } from './exceptions/errors';
 
 export { defineConfig } from './config';
 export { getBasePath } from './basePaths';
@@ -73,5 +77,29 @@ export class GraphicsKitPublisher {
     log.info(`Running: ${picocolors.green('delete')}`);
     const pack = new Pack();
     await pack.delete();
+  }
+
+  /**
+   * Re-open an AI diagnosis of the last command that failed, using the
+   * diagnostics file written to `.graphics-kit/diagnostics/latest.md`. Lets you
+   * look into a failure without re-running a slow command (e.g. a build).
+   */
+  @loadConfig
+  @withIntroOutro
+  async diagnose() {
+    log.info(`Running: ${picocolors.green('diagnose')}`);
+    const diagnosticsPath = latestDiagnosticsPath();
+    if (!fs.existsSync(diagnosticsPath)) {
+      throw new FileNotFoundError('No diagnostics found to diagnose.', {
+        code: 'NO_DIAGNOSTICS',
+        hint: 'Run a publisher command that fails first — it writes the diagnostics file this command re-opens.',
+        context: { expectedAt: diagnosticsPath },
+      });
+    }
+    await offerDiagnosisHandoff({
+      diagnosticsPath,
+      command: 'diagnose',
+      force: true,
+    });
   }
 }


### PR DESCRIPTION
Part **2 of 2** for #141 — the Claude Code handoff (Layer 3), building on the diagnostics foundation merged in #144.

## What it does

When a command fails **in an interactive terminal**, after the error is rendered the publisher offers a diagnosis handoff:

```
Your "upload" command failed. Diagnose it with AI?
> Open a Claude Code session to diagnose & fix it   (VSCode extension)
  Ask Claude what went wrong                         (claude in terminal)
  No thanks
```

- **Extension** → opens `vscode://anthropic.claude-code/open?prompt=…` (via the `open` package, as in `preview`), pre-filling — not submitting — a pointer to `.graphics-kit/diagnostics/latest.md`. Chat opens next to the code.
- **Terminal** → one-shot `claude -p` streaming a concise diagnosis.
- **No thanks / cancel** → prints the copy-paste command.

Auth is **out of scope** — we detect *availability* (`TERM_PROGRAM=vscode`, a real `claude` on PATH), never credentials; both handoffs soft-fail.

## Implementation notes

- **`src/diagnostics/handoff.ts`** — `offerDiagnosisHandoff()` is best-effort and never throws. Pure, unit-tested helpers (`isAiEnabled`, `detectSurfaces`, `buildPointer`, `buildExtensionUrl`, `isClaudeOnPath`) with a thin `select`/`open`/`spawn` shell. Bespoke cancel handling so cancelling never masks the failure exit code (the shared prompt wrappers `process.exit(0)`, which would).
- **`handleError` split** into `renderError` (no exit) + `handleError` (render+exit), so the prompt runs between rendering and exit. `runCommand` now: `renderError` → `await offerDiagnosisHandoff` → `exitCleanly(1)`.
- **`ai: 'prompt' | 'off'` config** (default `'prompt'`) + `--no-ai`. Skipped in CI / non-TTY.
- **`graphics-publisher diagnose`** — re-opens the handoff against the last diagnostics file (clean `FileNotFoundError` if none). An explicit `diagnose` bypasses the `ai:'off'`/`--no-ai` gate (those govern the *automatic* prompt).

## Tests
New: `handoff` (gating, surface detection, pointer/URL building, PATH detection via mock-fs), `config/validate` (the `ai` key), and a `renderError` no-exit test. **179/179 pass**, `tsc` + `pnpm build` + eslint clean. A `minor` changeset is included.

## Manual verification checklist for reviewers
- Failing build in a VSCode terminal → prompt appears; extension opens a pre-filled chat tab; terminal option streams `claude -p`; all paths exit non-zero.
- `--no-ai` / `ai: 'off'` / `CI=true` / piped → no prompt.
- `graphics-publisher diagnose` with and without a prior failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
