### PR TITLE
Sharpen likely-error heuristic and detect native-installed Claude

### DIFF
--- a/.changeset/diagnostics-heuristic-and-claude-detection.md
+++ b/.changeset/diagnostics-heuristic-and-claude-detection.md
@@ -1,0 +1,8 @@
+---
+'@reuters-graphics/graphics-kit-publisher': minor
+---
+
+Improve failure diagnostics: surface the real error and detect natively-installed Claude
+
+- The likely-error heuristic now scores an error together with its stack trace, so a runtime error whose frames point into your project (e.g. a `ReferenceError` thrown during SvelteKit prerendering) is surfaced ahead of the downstream SvelteKit HTTP-error wrapper that used to win. Errors whose entire trace is inside `node_modules` are demoted, and the surfaced window stops at blank-line block boundaries so it no longer bleeds into an unrelated error below it.
+- The Claude Code terminal handoff now finds Claude when it was installed with the native installer (which exposes `claude` only as a shell alias to `~/.claude/local/claude`, invisible to `PATH` and to `spawn`). The publisher resolves that location and spawns it by absolute path, so the "Ask Claude what went wrong" option appears for those users.

--- a/.changeset/diagnostics-heuristic-and-claude-detection.md
+++ b/.changeset/diagnostics-heuristic-and-claude-detection.md
@@ -1,5 +1,5 @@
 ---
-'@reuters-graphics/graphics-kit-publisher': minor
+'@reuters-graphics/graphics-kit-publisher': patch
 ---
 
 Improve failure diagnostics: surface the real error and detect natively-installed Claude

--- a/src/diagnostics/handoff.test.ts
+++ b/src/diagnostics/handoff.test.ts
@@ -6,6 +6,7 @@ import {
   buildPointer,
   buildExtensionUrl,
   isClaudeOnPath,
+  resolveClaudeBin,
 } from './handoff';
 
 describe('isAiEnabled', () => {
@@ -25,21 +26,22 @@ describe('isAiEnabled', () => {
 describe('detectSurfaces', () => {
   it('offers the extension only in a VSCode integrated terminal', () => {
     expect(
-      detectSurfaces({ termProgram: 'vscode', claudeOnPath: false }).extension
+      detectSurfaces({ termProgram: 'vscode', claudeBin: null }).extension
     ).toBe(true);
     expect(
-      detectSurfaces({ termProgram: 'Apple_Terminal', claudeOnPath: false })
+      detectSurfaces({ termProgram: 'Apple_Terminal', claudeBin: null })
         .extension
     ).toBe(false);
   });
 
-  it('offers the terminal only when claude is on PATH', () => {
+  it('offers the terminal only when a spawnable claude was resolved', () => {
     expect(
-      detectSurfaces({ termProgram: '', claudeOnPath: true }).terminal
+      detectSurfaces({ termProgram: '', claudeBin: '/usr/local/bin/claude' })
+        .terminal
     ).toBe(true);
-    expect(
-      detectSurfaces({ termProgram: '', claudeOnPath: false }).terminal
-    ).toBe(false);
+    expect(detectSurfaces({ termProgram: '', claudeBin: null }).terminal).toBe(
+      false
+    );
   });
 });
 
@@ -85,5 +87,37 @@ describe('isClaudeOnPath', () => {
     process.env.PATH = '/fake/bin';
     mockFs({ '/fake/bin/other': mockFs.file({ mode: 0o755, content: '' }) });
     expect(isClaudeOnPath()).toBe(false);
+  });
+});
+
+describe('resolveClaudeBin', () => {
+  afterEach(() => mockFs.restore());
+
+  it('returns the bare name when claude is a real executable on PATH', () => {
+    mockFs({ '/fake/bin/claude': mockFs.file({ mode: 0o755, content: '' }) });
+    expect(resolveClaudeBin({ path: '/fake/bin', home: '/home/me' })).toBe(
+      'claude'
+    );
+  });
+
+  it('falls back to the native-installer path when only the alias target exists', () => {
+    // The common native-install case: nothing on PATH, but the executable
+    // lives at ~/.claude/local/claude (exposed to the shell only via an alias).
+    mockFs({
+      '/home/me/.claude/local/claude': mockFs.file({
+        mode: 0o755,
+        content: '',
+      }),
+    });
+    expect(
+      resolveClaudeBin({ path: '/empty', home: '/home/me', platform: 'darwin' })
+    ).toBe('/home/me/.claude/local/claude');
+  });
+
+  it('returns null when claude is neither on PATH nor in the native location', () => {
+    mockFs({ '/home/me/.claude/local/other': mockFs.file({ mode: 0o755 }) });
+    expect(
+      resolveClaudeBin({ path: '/empty', home: '/home/me', platform: 'darwin' })
+    ).toBeNull();
   });
 });

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import os from 'os';
 import { spawn } from 'node:child_process';
 import { select, isCancel } from '@clack/prompts';
 import { note } from '@reuters-graphics/clack';
@@ -40,7 +41,7 @@ export const isAiEnabled = (
 export interface Surfaces {
   /** VSCode extension deep-link is viable (we're in an integrated terminal). */
   extension: boolean;
-  /** `claude` CLI is on PATH. */
+  /** A `claude` CLI we can actually spawn is available. */
   terminal: boolean;
 }
 
@@ -48,11 +49,12 @@ export interface Surfaces {
  * Which Claude Code surfaces are available — availability only, not credentials.
  */
 export const detectSurfaces = (
-  opts: { termProgram?: string; claudeOnPath?: boolean } = {}
+  opts: { termProgram?: string; claudeBin?: string | null } = {}
 ): Surfaces => {
   const termProgram = opts.termProgram ?? process.env.TERM_PROGRAM;
-  const claudeOnPath = opts.claudeOnPath ?? isClaudeOnPath();
-  return { extension: termProgram === 'vscode', terminal: claudeOnPath };
+  const claudeBin =
+    opts.claudeBin !== undefined ? opts.claudeBin : resolveClaudeBin();
+  return { extension: termProgram === 'vscode', terminal: !!claudeBin };
 };
 
 /** The short prompt handed to Claude — points at the file, never inlines it. */
@@ -67,11 +69,12 @@ export const buildExtensionUrl = (pointer: string): string =>
   `vscode://anthropic.claude-code/open?prompt=${encodeURIComponent(pointer)}`;
 
 /**
- * Resolve whether a real `claude` executable is on PATH. A shell *alias* is not
- * found — correct, since `spawn` can't use aliases either.
+ * Whether a real `claude` executable is on PATH. A shell *alias* is not found —
+ * correct, since `spawn` can't use aliases either (see {@link resolveClaudeBin}
+ * for the native-installer location that aliases point at).
  */
-export const isClaudeOnPath = (): boolean => {
-  const envPath = process.env.PATH;
+export const isClaudeOnPath = (opts: { path?: string } = {}): boolean => {
+  const envPath = opts.path ?? process.env.PATH;
   if (!envPath) return false;
   const extensions =
     process.platform === 'win32' ?
@@ -91,6 +94,39 @@ export const isClaudeOnPath = (): boolean => {
   return false;
 };
 
+/**
+ * Resolve a `claude` command we can actually {@link spawn}: the bare name when
+ * it's a real executable on PATH, otherwise the absolute path to the native
+ * installer's binary at `~/.claude/local/claude`.
+ *
+ * The native installer exposes Claude only through a shell *alias* pointing at
+ * that path — invisible to PATH and to `spawn`, so a PATH scan alone reports
+ * "not available" for those users even though Claude is installed. Checking the
+ * known location (and returning the absolute path for the caller to spawn) is
+ * what makes the terminal handoff appear for them. Returns null when neither is
+ * found.
+ */
+export const resolveClaudeBin = (
+  opts: { path?: string; home?: string; platform?: NodeJS.Platform } = {}
+): string | null => {
+  if (isClaudeOnPath({ path: opts.path })) return 'claude';
+
+  const home = opts.home ?? os.homedir();
+  const platform = opts.platform ?? process.platform;
+  const names =
+    platform === 'win32' ? ['claude.exe', 'claude.cmd', 'claude'] : ['claude'];
+  for (const name of names) {
+    const candidate = path.join(home, '.claude', 'local', name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // not the native-installer location
+    }
+  }
+  return null;
+};
+
 /* ------------------------------------------------------------------ */
 /* Interactive handoff                                                 */
 /* ------------------------------------------------------------------ */
@@ -101,9 +137,9 @@ const isInteractive = (): boolean =>
   !!process.stdin.isTTY;
 
 /** Run a one-shot `claude -p` diagnosis, streaming to the terminal. Never rejects. */
-const runTerminalDiagnosis = (pointer: string): Promise<void> =>
+const runTerminalDiagnosis = (pointer: string, bin: string): Promise<void> =>
   new Promise((resolve) => {
-    const child = spawn('claude', ['-p', pointer, '--output-format', 'text'], {
+    const child = spawn(bin, ['-p', pointer, '--output-format', 'text'], {
       cwd: context.cwd,
       stdio: 'inherit',
     });
@@ -126,7 +162,8 @@ export const offerDiagnosisHandoff = async ({
     if (!diagnosticsPath || !isInteractive()) return;
     if (!force && !isAiEnabled()) return;
 
-    const surfaces = detectSurfaces();
+    const claudeBin = resolveClaudeBin();
+    const surfaces = detectSurfaces({ claudeBin });
     const pointer = buildPointer(diagnosticsPath, command);
     const copyPasteNote = () =>
       note(
@@ -177,8 +214,8 @@ export const offerDiagnosisHandoff = async ({
       return;
     }
 
-    if (choice === 'terminal') {
-      await runTerminalDiagnosis(pointer);
+    if (choice === 'terminal' && claudeBin) {
+      await runTerminalDiagnosis(pointer, claudeBin);
     }
   } catch {
     // Never let the handoff mask the original failure.

--- a/src/diagnostics/likelyError.test.ts
+++ b/src/diagnostics/likelyError.test.ts
@@ -57,6 +57,28 @@ describe('extractLikelyErrors', () => {
     expect(extractLikelyErrors(log).join('\n')).toContain('+page.ts:3:10');
   });
 
+  it('surfaces the thrown error over the SvelteKit prerender wrapper below it', () => {
+    // Real shape of a SvelteKit prerender failure: the page's actual error is
+    // printed first, its frames point into the project's build output, and
+    // SvelteKit then wraps the failure in a 500 whose frames are all inside
+    // node_modules. We want the thrown error, not the wrapper/advice line.
+    const cwd = '/Users/me/project';
+    const log = [
+      '[500] GET /testfiles/2026/a4ui4SKDY2K/',
+      'ReferenceError: A_FAKE_VARIABLE is not defined',
+      `    at file://${cwd}/.svelte-kit/output/server/entries/pages/_page.svelte.js:11:15`,
+      `    at Renderer.child (file://${cwd}/.svelte-kit/output/server/chunks/server.js:3564:18)`,
+      '',
+      'Error: 500 /testfiles/2026/a4ui4SKDY2K/',
+      'To suppress or handle this error, implement `handleHttpError` in https://svelte.dev/docs/kit/configuration#prerender',
+      `    at file://${cwd}/node_modules/@sveltejs/kit/src/core/config/options.js:230:13`,
+      `    at save (file://${cwd}/node_modules/@sveltejs/kit/src/core/postbuild/prerender.js:492:4)`,
+    ].join('\n');
+    const out = extractLikelyErrors(log, { cwd }).join('\n');
+    expect(out).toContain('A_FAKE_VARIABLE is not defined');
+    expect(out).not.toContain('handleHttpError');
+  });
+
   it('falls back to the first N lines when nothing matches', () => {
     const out = extractLikelyErrors('line one\nline two\nline three', {
       maxLines: 2,

--- a/src/diagnostics/likelyError.ts
+++ b/src/diagnostics/likelyError.ts
@@ -29,8 +29,13 @@ const ERROR_SIGNATURES: RegExp[] = [
   /ERR_MODULE_NOT_FOUND/,
   /Cannot find package/i,
   /\bENOENT\b/,
-  // SvelteKit prerender (adapter-static)
-  /prerender/i,
+  // NOTE: we deliberately do NOT match SvelteKit's prerender HTTP-error
+  // wrapper (`Error: <code> /route` + the `handleHttpError` / `#prerender`
+  // advice line). When a page throws during prerender, SvelteKit always wraps
+  // the failure in that wrapper — it's a symptom, and the real error (a
+  // ReferenceError, etc.) is printed just above it. Leaving the wrapper
+  // unmatched lets the actual thrown error win. A genuine prerender *config*
+  // error still starts with `Error:` and is caught by the generic fallback.
   // TypeScript (rare in `vite build`, but cheap to keep)
   /error TS\d+/i,
   // Generic JS runtime/syntax
@@ -53,6 +58,34 @@ const ERROR_SIGNATURES: RegExp[] = [
 
 /** Boost applied to a line that references the user's own project source. */
 const PROJECT_REFERENCE_BOOST = 100;
+
+/**
+ * Penalty applied when an error's entire associated stack trace sits inside
+ * `node_modules` — dependency-internal noise that should lose to anything
+ * pointing at the user's own code.
+ */
+const NODE_MODULES_PENALTY = 50;
+
+/** A stack-trace frame line, e.g. `    at foo (file:///…/x.js:1:2)`. */
+function isStackFrame(line: string): boolean {
+  return /^\s*at\s/.test(line) || /\bfile:\/\//.test(line);
+}
+
+/**
+ * Whether a single line points at the user's own code: it names their `src/`
+ * tree, a `.svelte` file, a `file.ext:line` location, or (when known) the
+ * project root — but never a `node_modules` path (that's dependency noise,
+ * and the guard also stops a `.../node_modules/.../src/...` false positive).
+ */
+function referencesProjectLine(line: string, cwd?: string): boolean {
+  if (/node_modules/.test(line)) return false;
+  return (
+    (!!cwd && line.includes(cwd)) ||
+    /(^|[^\w])src[\\/]/.test(line) ||
+    /\.svelte\b/.test(line) ||
+    /\.(?:svelte|ts|js|mjs|scss|css):\d+/.test(line)
+  );
+}
 
 export interface ExtractLikelyErrorsOptions {
   /** Absolute project root; lines mentioning it are preferred. */
@@ -89,19 +122,30 @@ export function extractLikelyErrors(
     const signatureRank = ERROR_SIGNATURES.findIndex((re) => re.test(line));
     if (signatureRank === -1) continue;
 
-    // A line points at the user's own code if it names their src/ tree, a
-    // `.svelte` file, or a `file.ext:line` location — but not if it's inside
-    // node_modules (that's dependency noise, not their bug).
-    const inNodeModules = /node_modules/.test(line);
+    // Associate the contiguous stack-trace block beneath this line with it, so
+    // a bare error header ("ReferenceError: x is not defined") inherits the
+    // project signal from its frames — the decisive clue for whether the fault
+    // is in the user's code or a dependency.
+    const trace: string[] = [];
+    for (let j = i + 1; j < lines.length && isStackFrame(lines[j]); j++) {
+      trace.push(lines[j]);
+    }
+
+    // The error points at the user's own code if the header or any of its
+    // frames does; it's dependency noise if it has a trace and every frame
+    // lives in node_modules.
     const referencesProject =
-      !inNodeModules &&
-      ((!!cwd && line.includes(cwd)) ||
-        /(^|[^\w])src[\\/]/.test(line) ||
-        /\.svelte\b/.test(line) ||
-        /\.(?:svelte|ts|js|mjs|scss|css):\d+/.test(line));
-    // Lower score is better; a project reference strongly outranks signature order.
-    const score =
-      signatureRank - (referencesProject ? PROJECT_REFERENCE_BOOST : 0);
+      referencesProjectLine(line, cwd) ||
+      trace.some((frame) => referencesProjectLine(frame, cwd));
+    const allFramesInNodeModules =
+      trace.length > 0 && trace.every((frame) => /node_modules/.test(frame));
+
+    // Lower score is better; a project reference strongly outranks signature
+    // order, while an all-node_modules trace is demoted below it.
+    let score = signatureRank;
+    if (referencesProject) score -= PROJECT_REFERENCE_BOOST;
+    else if (allFramesInNodeModules) score += NODE_MODULES_PENALTY;
+
     if (score < bestScore) {
       bestScore = score;
       bestIndex = i;
@@ -115,8 +159,18 @@ export function extractLikelyErrors(
       .slice(0, maxLines);
   }
 
-  // Return a small window around the best match (one line of lead-in for context).
+  // Return a small window around the best match (one line of lead-in for
+  // context), capped at maxLines. Stop at the first blank line after the match:
+  // build logs use blank lines to delimit separate error blocks, so this keeps
+  // the window from bleeding into an unrelated downstream error (e.g. the
+  // SvelteKit prerender wrapper printed below a page's thrown error).
   const start = Math.max(0, bestIndex - 1);
-  const end = Math.min(lines.length, start + maxLines);
+  let end = Math.min(lines.length, start + maxLines);
+  for (let i = bestIndex + 1; i < end; i++) {
+    if (lines[i].trim().length === 0) {
+      end = i;
+      break;
+    }
+  }
   return reflowText(lines.slice(start, end).join('\n'), width);
 }


### PR DESCRIPTION
Two follow-up improvements to the 3.4.0 error-diagnostics feature, found while testing against a real project.

## Likely-error heuristic ([likelyError.ts](src/diagnostics/likelyError.ts))
A `ReferenceError` thrown during SvelteKit prerendering was being upstaged by the downstream SvelteKit HTTP-error wrapper (`Error: 500 /route` + the `handleHttpError` advice line), because scoring only looked at the single matched line and the over-broad `/prerender/i` signature outranked the real error.

- Score an error **together with its trailing stack trace**, so a bare `ReferenceError: … is not defined` inherits the project signal from its frames.
- Boost when the header or any frame points into the project; **penalize** when the whole trace is inside `node_modules` (dependency-internal noise).
- Remove the over-broad `/prerender/i` signature (it matched boilerplate advice, not the cause).
- Stop the surfaced window at blank-line block boundaries so it no longer bleeds into an unrelated error below.

## Claude detection ([handoff.ts](src/diagnostics/handoff.ts))
The terminal handoff missed Claude installed via the **native installer**, which exposes `claude` only as a shell alias to `~/.claude/local/claude` — invisible to `PATH` and to `spawn`. The "Ask Claude what went wrong" option never appeared for those users.

- Add `resolveClaudeBin()`: returns the bare name when a real `claude` is on `PATH`, else the absolute native-install path.
- Thread the resolved command through detection **and** invocation so they can't disagree; spawn the absolute path when found there.

## Tests
- Regression test built from the real failing log (surfaces the `ReferenceError`, not `handleHttpError`).
- New `resolveClaudeBin` coverage (PATH hit, native-location fallback, not-found).
- Full suite green (183 tests), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)