### PR TITLE
Improve terminal AI diagnosis UX

### DIFF
--- a/.changeset/terminal-diagnosis-ux.md
+++ b/.changeset/terminal-diagnosis-ux.md
@@ -1,0 +1,9 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Improve the terminal AI diagnosis UX
+
+- Show a spinner while Claude works, so the terminal no longer looks hung while waiting for a response.
+- Capture Claude's output and print it in a word-wrapped note (wrapped to the terminal width) instead of letting long unwrapped lines overflow the box.
+- Drop Claude's operational stderr notices (e.g. the "claude.ai connectors are disabled…" warning) on success, but surface stderr when the command fails so real problems like auth errors aren't silently swallowed.

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -3,11 +3,12 @@ import fs from 'fs';
 import os from 'os';
 import { spawn } from 'node:child_process';
 import { select, isCancel } from '@clack/prompts';
-import { note } from '@reuters-graphics/clack';
+import { note, spinner } from '@reuters-graphics/clack';
 import picocolors from 'picocolors';
 import open from 'open';
 import { utils } from '@reuters-graphics/graphics-bin';
 import { context } from '../context';
+import { reflowText } from '../utils/reflowText';
 
 export interface HandoffOptions {
   /** Absolute path to the diagnostics file, or null if none was written. */
@@ -136,15 +137,62 @@ const isInteractive = (): boolean =>
   !!process.stdout.isTTY &&
   !!process.stdin.isTTY;
 
-/** Run a one-shot `claude -p` diagnosis, streaming to the terminal. Never rejects. */
-const runTerminalDiagnosis = (pointer: string, bin: string): Promise<void> =>
+/**
+ * Print a note, word-wrapping the message to the terminal width first. `note`
+ * sizes its box to the longest line and does not wrap, so an LLM's long
+ * unwrapped paragraph lines would otherwise blow the box past the terminal.
+ */
+const reflowedNote = (message: string, title: string): void => {
+  // Leave room for the box chrome (`│  ` … `  │`); cap width for readability.
+  const width = Math.max(40, Math.min(process.stdout.columns ?? 80, 100) - 6);
+  note(reflowText(message, width).join('\n'), title);
+};
+
+/**
+ * Run a one-shot `claude -p` diagnosis. Shows a spinner while Claude works so
+ * the terminal doesn't look hung, and captures both streams.
+ *
+ * On success (exit 0 with output) it prints the diagnosis and drops stderr —
+ * Claude emits operational notices there (e.g. auth/connector warnings) that
+ * are just noise on the happy path. On failure it surfaces the captured stderr
+ * so a real problem (an auth error, say) isn't silently swallowed. Resolves
+ * true when a diagnosis was produced; never rejects.
+ */
+const runTerminalDiagnosis = (pointer: string, bin: string): Promise<boolean> =>
   new Promise((resolve) => {
+    const s = spinner(2000);
+    s.start('Asking Claude to look at the error');
+
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
     const child = spawn(bin, ['-p', pointer, '--output-format', 'text'], {
       cwd: context.cwd,
-      stdio: 'inherit',
+      // Capture both streams (the spinner owns the parent terminal); we decide
+      // what to surface once we know the exit code.
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
-    child.on('close', () => resolve());
-    child.on('error', () => resolve());
+
+    child.stdout?.on('data', (chunk: Buffer) => out.push(chunk));
+    child.stderr?.on('data', (chunk: Buffer) => err.push(chunk));
+
+    child.on('close', async (code) => {
+      const text = Buffer.concat(out).toString('utf8').trim();
+      if (code === 0 && text) {
+        await s.stop('Claude looked at your error:');
+        reflowedNote(text, 'AI diagnosis');
+        resolve(true);
+      } else {
+        await s.stop("Claude couldn't diagnose the error.");
+        const errText = Buffer.concat(err).toString('utf8').trim();
+        if (errText) reflowedNote(errText, 'Claude error');
+        resolve(false);
+      }
+    });
+
+    child.on('error', async () => {
+      await s.stop("Couldn't run Claude.");
+      resolve(false);
+    });
   });
 
 /**
@@ -215,7 +263,8 @@ export const offerDiagnosisHandoff = async ({
     }
 
     if (choice === 'terminal' && claudeBin) {
-      await runTerminalDiagnosis(pointer, claudeBin);
+      const ok = await runTerminalDiagnosis(pointer, claudeBin);
+      if (!ok) copyPasteNote();
     }
   } catch {
     // Never let the handoff mask the original failure.


### PR DESCRIPTION
Follow-up UX polish for the terminal `claude -p` diagnosis handoff, from testing in a real project.

## Changes ([handoff.ts](src/diagnostics/handoff.ts))
- **Spinner while Claude works** — previously the terminal just sat there with no output until Claude responded, which looked hung. Now a clack spinner runs until the response arrives.
- **Word-wrapped output** — `note` sizes its box to the longest line and does not wrap, so Claude's long unwrapped paragraph lines produced a box wider than the terminal (measured 241 cols at an 80-col width). Output is now reflowed to the terminal width (via the existing `reflowText` util, which preserves paragraph breaks and short lines) before printing.
- **Smarter stderr handling** — Claude emits operational notices on stderr even on success (e.g. `⚠ claude.ai connectors are disabled…`). We now:
  - **drop stderr on success** (exit 0 with output) so that warning no longer surfaces, but
  - **surface stderr on failure** (non-zero exit) so a real problem like an auth error isn't silently swallowed. Verified empirically that the response is on stdout and the warning is on stderr.
- On failure the caller still shows the copy-paste fallback command.

## Notes
- Buffered, not streamed — output appears when Claude finishes (the spinner and live streaming can't cleanly share the terminal).
- `reflowText` wraps on whitespace, so a very long *code* line in a diagnosis would lose its original indentation; fine for prose, a minor cosmetic cost for pasted code.

tsc clean, prettier clean, all 32 diagnostics tests pass (183 full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)