### PR TITLE
Frame the runner error that follows a terminal AI diagnosis

### DIFF
--- a/.changeset/frame-runner-error-after-diagnosis.md
+++ b/.changeset/frame-runner-error-after-diagnosis.md
@@ -1,0 +1,7 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Frame the runner error that follows a terminal AI diagnosis
+
+After Claude prints a diagnosis in the terminal, the failed command still exits non-zero (so script runners like `npm-run-all` halt and CI fails), which means a runner error like `ELIFECYCLE Command failed with exit code 1` prints right after the diagnosis. That made it look like Claude itself had errored. The publisher now prints a short line between the diagnosis and the runner's error to frame it as the original command's failure. Only shown when the diagnosis ran in the terminal — the VSCode extension path opens the diagnosis elsewhere.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import sade from 'sade';
+import picocolors from 'picocolors';
 import { version } from '../package.json';
 import { GraphicsKitPublisher } from '.';
 import { renderError, PublisherError } from './exceptions/errors';
@@ -34,7 +35,22 @@ const runCommand = async (command: string, action: () => Promise<void>) => {
     const diagnosticsPath = writeDiagnostics(error, command);
     renderError(error, { command, diagnosticsPath });
     // Offer the Claude Code handoff after the error is shown, before we exit.
-    await offerDiagnosisHandoff({ diagnosticsPath, command });
+    const terminalDiagnosed = await offerDiagnosisHandoff({
+      diagnosticsPath,
+      command,
+    });
+    // The command genuinely failed, so we always exit non-zero — script runners
+    // like npm-run-all must halt (and never proceed to commit/push a broken
+    // build), and CI must fail. But when Claude just printed a diagnosis in this
+    // terminal, frame the runner's trailing "exited with 1" so it doesn't read
+    // as Claude itself erroring.
+    if (terminalDiagnosed) {
+      console.error(
+        picocolors.dim(
+          `\n↑ Claude's diagnosis is above. Errors from the failed "${command}" command below ↓`
+        )
+      );
+    }
     exitCleanly(1);
   }
 };

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -200,15 +200,23 @@ const runTerminalDiagnosis = (pointer: string, bin: string): Promise<boolean> =>
  * VSCode extension (chat next to the code) or a one-shot `claude -p` in the
  * terminal. Best-effort and never throws; returns without prompting when a
  * handoff isn't possible (disabled, non-interactive, or nothing available).
+ *
+ * Resolves `true` only when a diagnosis was printed *to this terminal* (the
+ * `claude -p` path). The caller does NOT use this to change the exit code — the
+ * command still failed and must exit non-zero so script runners (e.g.
+ * npm-run-all) halt and CI fails — but to frame the runner's trailing error,
+ * which only makes sense when the diagnosis is right there above it. The
+ * extension path opens the diagnosis in VSCode, not the terminal, so it
+ * resolves `false`.
  */
 export const offerDiagnosisHandoff = async ({
   diagnosticsPath,
   command,
   force = false,
-}: HandoffOptions): Promise<void> => {
+}: HandoffOptions): Promise<boolean> => {
   try {
-    if (!diagnosticsPath || !isInteractive()) return;
-    if (!force && !isAiEnabled()) return;
+    if (!diagnosticsPath || !isInteractive()) return false;
+    if (!force && !isAiEnabled()) return false;
 
     const claudeBin = resolveClaudeBin();
     const surfaces = detectSurfaces({ claudeBin });
@@ -221,7 +229,7 @@ export const offerDiagnosisHandoff = async ({
 
     if (!surfaces.extension && !surfaces.terminal) {
       copyPasteNote();
-      return;
+      return false;
     }
 
     const options: { value: string; label: string; hint?: string }[] = [];
@@ -246,7 +254,7 @@ export const offerDiagnosisHandoff = async ({
 
     if (isCancel(choice) || choice === 'no') {
       copyPasteNote();
-      return;
+      return false;
     }
 
     if (choice === 'extension') {
@@ -259,14 +267,20 @@ export const offerDiagnosisHandoff = async ({
       } catch {
         copyPasteNote();
       }
-      return;
+      // The diagnosis opens in VSCode, not this terminal, so there's nothing
+      // above the runner's error to frame — resolve false either way.
+      return false;
     }
 
     if (choice === 'terminal' && claudeBin) {
       const ok = await runTerminalDiagnosis(pointer, claudeBin);
       if (!ok) copyPasteNote();
+      return ok;
     }
+
+    return false;
   } catch {
     // Never let the handoff mask the original failure.
+    return false;
   }
 };


### PR DESCRIPTION
When a command fails and the user asks Claude to diagnose it in the terminal, the command still exits non-zero — so a script runner like `npm-run-all` prints `ELIFECYCLE Command failed with exit code 1` immediately after Claude's diagnosis box. That reads as if Claude itself errored.

## Why not just exit 0?
Considered and rejected. The demo project's `preview` script is `npm-run-all publish:preview stories:autolink publish:git-commit` — exiting 0 on a failed build would let the chain continue and **commit & push a broken build**. Exit non-zero must stand (runners halt, CI fails). The only safe fix is framing.

## Change
- `offerDiagnosisHandoff` now returns whether a diagnosis printed **to this terminal** (`claude -p` path). The extension path opens the diagnosis in VSCode, so it returns `false` — nothing above the runner error to frame.
- The CLI failure boundary ([cli.ts](src/cli.ts)) prints a dim line when a terminal diagnosis was shown:
  > `↑ Claude's diagnosis is above. Errors from the failed "preview" command below ↓`
- Kept at the failure boundary (not inside the handoff) on purpose: the `diagnose` command reuses the handoff on its *success* path, where there is no failure and nothing follows.

Exit code is unchanged (always non-zero on failure).

tsc clean, prettier clean, all 183 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)