### PR TITLE
Fix AI-handoff prompt wording for the diagnose command

### DIFF
--- a/.changeset/diagnose-prompt-wording.md
+++ b/.changeset/diagnose-prompt-wording.md
@@ -1,0 +1,7 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Fix the AI-handoff prompt wording for the `diagnose` command
+
+The `diagnose` command re-opens the last failure on demand, but reused the automatic post-failure prompt — so it asked "Your \"diagnose\" command failed. Diagnose it with AI?", which read as though `diagnose` itself had errored. It now asks "Diagnose the last failed command with AI?".

--- a/src/diagnostics/handoff.test.ts
+++ b/src/diagnostics/handoff.test.ts
@@ -5,6 +5,7 @@ import {
   detectSurfaces,
   buildPointer,
   buildExtensionUrl,
+  buildPromptMessage,
   isClaudeOnPath,
   resolveClaudeBin,
 } from './handoff';
@@ -55,6 +56,20 @@ describe('buildPointer', () => {
   it('omits the command when absent', () => {
     expect(buildPointer('/p/latest.md')).toBe(
       'Read /p/latest.md and diagnose the failure.'
+    );
+  });
+});
+
+describe('buildPromptMessage', () => {
+  it('names the failed command for the automatic post-failure prompt', () => {
+    expect(buildPromptMessage({ command: 'preview' })).toBe(
+      'Your "preview" command failed. Diagnose it with AI?'
+    );
+  });
+
+  it('does not claim a failure when re-opened via the diagnose command', () => {
+    expect(buildPromptMessage({ command: 'diagnose', reopened: true })).toBe(
+      'Diagnose the last failed command with AI?'
     );
   });
 });

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -70,6 +70,19 @@ export const buildExtensionUrl = (pointer: string): string =>
   `vscode://anthropic.claude-code/open?prompt=${encodeURIComponent(pointer)}`;
 
 /**
+ * The select-prompt question. The automatic prompt fires right after a command
+ * failed, so it names that command; the `diagnose` command (`reopened`) instead
+ * re-opens the last failure on demand, so it must not claim `diagnose` itself
+ * failed.
+ */
+export const buildPromptMessage = (
+  opts: { command?: string; reopened?: boolean } = {}
+): string =>
+  opts.reopened ?
+    'Diagnose the last failed command with AI?'
+  : `Your "${opts.command ?? 'command'}" command failed. Diagnose it with AI?`;
+
+/**
  * Whether a real `claude` executable is on PATH. A shell *alias* is not found —
  * correct, since `spawn` can't use aliases either (see {@link resolveClaudeBin}
  * for the native-installer location that aliases point at).
@@ -248,7 +261,7 @@ export const offerDiagnosisHandoff = async ({
     options.push({ value: 'no', label: 'No thanks' });
 
     const choice = await select({
-      message: `Your "${command ?? 'command'}" command failed. Diagnose it with AI?`,
+      message: buildPromptMessage({ command, reopened: force }),
       options,
     });
 


### PR DESCRIPTION
The `diagnose` command re-opens the last failure on demand, but it reused the automatic post-failure prompt — so it asked:

> Your "diagnose" command failed. Diagnose it with AI?

which reads as though `diagnose` itself errored. It didn't; it's re-opening a *previous* failure.

## Change ([handoff.ts](src/diagnostics/handoff.ts))
- Extract the prompt text into a pure, tested `buildPromptMessage` helper.
- Key it on the existing `force` flag (set only by the explicit `diagnose` command, documented as "a deliberate request") so a re-open reads:
  > Diagnose the last failed command with AI?
- The automatic post-failure prompt is unchanged (`Your "preview" command failed. …`).

## Tests
- Two new cases for `buildPromptMessage` (automatic vs re-opened). 15 handoff tests pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)