### PR TITLE
Stop the pack spinner when packing fails

### DIFF
--- a/.changeset/pack-spinner-leak-on-error.md
+++ b/.changeset/pack-spinner-leak-on-error.md
@@ -1,0 +1,7 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Stop the "Packing up graphic pack" spinner when packing fails
+
+If a pack failed mid-way (e.g. a missing `og:image` tag), the packing spinner kept animating underneath the rendered error and the AI-handoff prompt, making it look like the process was still running. `packUp` now stops the spinner on failure and rethrows, matching how every other spinner in the publisher already handles errors.

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -122,11 +122,19 @@ export class Pack {
   async packUp() {
     const s = spinner(2000);
     s.start('Packing up graphic pack');
-    utils.fs.ensureDir(this.packRoot);
-    for (const archive of this.archives) {
-      await archive.packUp();
+    try {
+      utils.fs.ensureDir(this.packRoot);
+      for (const archive of this.archives) {
+        await archive.packUp();
+      }
+      await s.stop('📦 All packed.');
+    } catch (error) {
+      // Stop the spinner on failure so it doesn't keep animating under the
+      // rendered error and the AI-handoff prompt. Rethrow so the failure still
+      // reaches the CLI error boundary.
+      await s.stop('Could not finish packing up.', 2);
+      throw error;
     }
-    await s.stop('📦 All packed.');
   }
 
   async resetPackData(askToConfirm = true) {


### PR DESCRIPTION
When a pack failed mid-way (e.g. a `MISSING_OG_IMAGE` error), the "Packing up graphic pack" spinner kept animating **underneath** the rendered error and the AI-handoff prompt — making it look like the process was still running (and, briefly, like Claude might have errored).

## Cause
`packUp` started a spinner but only called `s.stop()` on the success path. When `archive.packUp()` threw, the error propagated straight past it to the CLI boundary, and the spinner object was out of scope — so nothing stopped its animation interval.

## Fix ([pack/index.ts](src/pack/index.ts))
Wrap the body in try/catch: on failure, stop the spinner with an error symbol and rethrow so the failure still reaches the CLI error boundary.

## Audit
`packUp` was the **only** unguarded spinner-ownership site. Verified the rest already stop on throw and rethrow:
- `build` → `validateOutDir` stops the spinner before throwing
- `pack.createOrUpdate` / `archive` (serverSpinner) → try/catch stops + rethrows
- `separateAssets` → try/catch stops (swallows the error — separate concern)

tsc + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)