### PR TITLE
Skip build logs in diagnostics for the publisher's own rule errors

### DIFF
--- a/.changeset/diagnostics-skip-build-logs-for-rule-errors.md
+++ b/.changeset/diagnostics-skip-build-logs-for-rule-errors.md
@@ -1,0 +1,7 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Don't surface build logs in diagnostics for the publisher's own rule errors
+
+When a failure was thrown by an internal publisher rule (e.g. `MISSING_OG_IMAGE`) rather than delegated from the build, the diagnostics file still scraped a "Likely cause" from the last build's logs and dumped the `error.log`/`out.log` tails — a red herring, since the build had succeeded. The diagnostics file now includes build logs and a scraped likely cause only for delegated errors (those that carry `logPaths`), matching what the terminal error output already did. Internal rule errors stand on their message, hint, context, and the publisher rule docs.

--- a/src/diagnostics/index.test.ts
+++ b/src/diagnostics/index.test.ts
@@ -13,7 +13,7 @@ vi.mock('../context', () => ({
 vi.mock('@reuters-graphics/clack', () => ({ note: vi.fn() }));
 
 import { writeDiagnostics } from './index';
-import { BuildError } from '../exceptions/errors';
+import { BuildError, PageMetadataError } from '../exceptions/errors';
 import { note } from '@reuters-graphics/clack';
 
 const LATEST = path.join(
@@ -104,5 +104,28 @@ describe('writeDiagnostics', () => {
     expect(written).toBe(LATEST);
     expect(fs.existsSync(LATEST)).toBe(true);
     expect(fs.existsSync(GITIGNORE)).toBe(false);
+  });
+
+  it('omits build logs for an internal rule error (no logPaths)', () => {
+    // The build succeeded; the failure was thrown by a publisher rule. The
+    // build logs on disk are unrelated noise and must not be surfaced.
+    mockFs(projectFs({ gitignore: '.graphics-kit/\n' }));
+
+    const ruleErr = new PageMetadataError(
+      'No "og:image" tag found in map.html',
+      {
+        code: 'MISSING_OG_IMAGE',
+        hint: 'Add an <meta property="og:image"> tag to the page.',
+      }
+    );
+    const written = writeDiagnostics(ruleErr, 'upload');
+
+    const content = fs.readFileSync(written!, 'utf8');
+    // The self-describing error still leads the diagnosis...
+    expect(content).toContain('MISSING_OG_IMAGE');
+    // ...but the build logs and scraped "likely cause" are gone.
+    expect(content).not.toContain('Likely cause');
+    expect(content).not.toContain('Log: error.log');
+    expect(content).not.toContain('Log: out.log');
   });
 });

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -46,22 +46,28 @@ const buildContent = (error: unknown, command?: string): string => {
   const isPublisherError = err instanceof PublisherError;
   const cmd = command ?? (isPublisherError ? err.command : undefined);
 
-  const errLog = readTail(logs.errLogPath);
-  const outLog = readTail(logs.outLogPath);
+  // A delegated error names the log files where the *real* failure lives (a
+  // build/subprocess), so we scrape a likely cause from them and include the
+  // log tails. An internal rule error (e.g. MISSING_OG_IMAGE) is thrown by the
+  // publisher *after* the build succeeded — its build logs are unrelated noise
+  // and a red herring, so we surface neither and let the error message, hint,
+  // and rule docs carry the diagnosis.
+  const logPaths = isPublisherError && err.logPaths?.length ? err.logPaths : [];
+  const isDelegated = logPaths.length > 0;
 
-  // Prefer the error's own logPaths (delegated errors); otherwise fall back to error.log.
   let likely: string[] = [];
-  const logPaths = isPublisherError && err.logPaths ? err.logPaths : [];
-  for (const logPath of logPaths) {
-    const tail = readTail(logPath);
-    if (tail) {
-      likely = extractLikelyErrors(tail, { cwd: context.cwd });
-      if (likely.length) break;
+  if (isDelegated) {
+    for (const logPath of logPaths) {
+      const tail = readTail(logPath);
+      if (tail) {
+        likely = extractLikelyErrors(tail, { cwd: context.cwd });
+        if (likely.length) break;
+      }
     }
   }
-  if (!likely.length && errLog) {
-    likely = extractLikelyErrors(errLog, { cwd: context.cwd });
-  }
+
+  const errLog = isDelegated ? readTail(logs.errLogPath) : null;
+  const outLog = isDelegated ? readTail(logs.outLogPath) : null;
 
   const lines: string[] = [];
   lines.push('# Publisher diagnostics');


### PR DESCRIPTION
When a failure is thrown by an **internal publisher rule** (e.g. `MISSING_OG_IMAGE`) rather than delegated from the build, the diagnostics file still scraped a "Likely cause" from the last build's logs and dumped the `error.log`/`out.log` tails. But the build had **succeeded** — so that build output (maplibre tolerated-transform warnings, chunk-size notices) was a pure red herring, pointing the AI away from the real cause.

## Cause
`buildContent` read the build logs unconditionally, and for errors without `logPaths` it *fell back* to scraping `error.log` for a likely cause. Internal rule errors don't carry `logPaths`, so they hit that fallback and surfaced stale build noise.

## Fix ([index.ts](src/diagnostics/index.ts))
Gate both the likely-cause scrape **and** the `error.log`/`out.log` tails on whether the error is delegated (carries `logPaths`, i.e. the real failure lives in those logs). Internal rule errors now stand on their message, hint, context, and the publisher rule docs.

This matches what the terminal already did — `renderError` was already gating its "Likely cause" on `error.logPaths?.length`; only the diagnostics file had the stray fallback. Now they're consistent.

## Test
New case: an internal `PageMetadataError` (no `logPaths`) produces a diagnostics file that contains `MISSING_OG_IMAGE` but neither "Likely cause" nor the log-tail sections. 35 diagnostics tests pass; tsc + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)