### PR TITLE
Polish the terminal AI-diagnosis prompt

### DIFF
--- a/.changeset/diagnosis-prompt-polish.md
+++ b/.changeset/diagnosis-prompt-polish.md
@@ -1,0 +1,8 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Polish the terminal AI-diagnosis prompt
+
+- Make the "Diagnose it with AI?" select prompt stand out as the one interactive decision point: a ⛔ prefix, bold text, the command name in cyan, and "AI" in yellow.
+- Add breathing room (blank lines) around the line that frames the runner's trailing error after a terminal diagnosis, so it isn't crowded against the `ELIFECYCLE` output.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ const runCommand = async (command: string, action: () => Promise<void>) => {
     if (terminalDiagnosed) {
       console.error(
         picocolors.dim(
-          `\n↑ Claude's diagnosis is above. Errors from the failed "${command}" command below ↓`
+          `\n↑ Claude's diagnosis is above. Errors from the failed "${command}" command below ↓\n`
         )
       );
     }

--- a/src/diagnostics/handoff.test.ts
+++ b/src/diagnostics/handoff.test.ts
@@ -61,16 +61,23 @@ describe('buildPointer', () => {
 });
 
 describe('buildPromptMessage', () => {
+  // The message is styled (bold + colour); assert on the semantic text so the
+  // tests hold whether or not colour is enabled in the run environment.
+  // eslint-disable-next-line no-control-regex
+  const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '');
+
   it('names the failed command for the automatic post-failure prompt', () => {
-    expect(buildPromptMessage({ command: 'preview' })).toBe(
+    expect(stripAnsi(buildPromptMessage({ command: 'preview' }))).toContain(
       'Your "preview" command failed. Diagnose it with AI?'
     );
   });
 
   it('does not claim a failure when re-opened via the diagnose command', () => {
-    expect(buildPromptMessage({ command: 'diagnose', reopened: true })).toBe(
-      'Diagnose the last failed command with AI?'
+    const out = stripAnsi(
+      buildPromptMessage({ command: 'diagnose', reopened: true })
     );
+    expect(out).toContain('Diagnose the last failed command with AI?');
+    expect(out).not.toContain('"diagnose" command failed');
   });
 });
 

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -70,17 +70,28 @@ export const buildExtensionUrl = (pointer: string): string =>
   `vscode://anthropic.claude-code/open?prompt=${encodeURIComponent(pointer)}`;
 
 /**
- * The select-prompt question. The automatic prompt fires right after a command
- * failed, so it names that command; the `diagnose` command (`reopened`) instead
- * re-opens the last failure on demand, so it must not claim `diagnose` itself
- * failed.
+ * The styled select-prompt question — one source of truth for both wordings.
+ * The automatic prompt fires right after a command failed, so it names that
+ * command; the `diagnose` command (`reopened`) re-opens the last failure on
+ * demand, so it must not claim `diagnose` itself failed.
+ *
+ * The command name and "AI" are coloured to draw the eye, and the whole line is
+ * bold behind a ⛔ so this one interactive decision point stands out from the
+ * error output above and the options below. (⛔ is a single-codepoint,
+ * default-emoji glyph, so it keeps a consistent 2-cell width across terminals,
+ * unlike ⚠️, which needs a variation selector.) The trailing newline gives the
+ * question breathing room from the option list.
  */
 export const buildPromptMessage = (
   opts: { command?: string; reopened?: boolean } = {}
-): string =>
-  opts.reopened ?
-    'Diagnose the last failed command with AI?'
-  : `Your "${opts.command ?? 'command'}" command failed. Diagnose it with AI?`;
+): string => {
+  const ai = picocolors.yellow('AI');
+  const question =
+    opts.reopened ?
+      `Diagnose the last failed command with ${ai}?`
+    : `Your "${picocolors.cyan(opts.command ?? 'command')}" command failed. Diagnose it with ${ai}?`;
+  return `${picocolors.bold(`⛔ ${question}`)}\n`;
+};
 
 /**
  * Whether a real `claude` executable is on PATH. A shell *alias* is not found —


### PR DESCRIPTION
Two small UX touches to the terminal diagnosis flow.

## Prompt styling ([handoff.ts](src/diagnostics/handoff.ts))
Make the "Diagnose it with AI?" `select` the clear interactive decision point:
- `⛔` prefix (single-codepoint emoji → consistent 2-cell width across terminals, unlike `⚠️` which needs a variation selector)
- whole line bold
- command name in **cyan**, "AI" in **yellow** — draws the eye to what failed and the choice being offered
- trailing blank line so the question isn't crowded against the options

Styling lives in `buildPromptMessage` as the single source of truth for both the automatic and `diagnose`-reopen wordings (interior colours can't be applied cleanly at the call site). Its unit tests now strip ANSI and assert on semantic text, so they hold whether or not colour is enabled.

## Framing-line spacing ([cli.ts](src/cli.ts))
Add blank lines around the line that frames the runner's trailing error after a terminal diagnosis, so it isn't crowded against `ELIFECYCLE Command failed with exit code 1`.

15 handoff tests pass; tsc + prettier + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)