### PR TITLE
Render the terminal AI diagnosis as readable, coloured text

### DIFF
--- a/.changeset/terminal-diagnosis-markdown-render.md
+++ b/.changeset/terminal-diagnosis-markdown-render.md
@@ -1,0 +1,12 @@
+---
+'@reuters-graphics/graphics-kit-publisher': patch
+---
+
+Render the terminal AI diagnosis as readable, coloured text
+
+Claude replies in Markdown, which read poorly in the terminal — raw `##` headings, `**bold**`, `[text](url)` links, and code fences. The terminal diagnosis now:
+
+- Renders that Markdown to coloured terminal text (bold yellow headings, bold emphasis, cyan inline/fenced code, bullets as `•`, and links collapsed to just their text).
+- Adapts the one-shot `claude -p` prompt so the reply is terminal-friendly: concise, `path:line` file references instead of Markdown links, and no closing question the user can't answer (this is a single non-interactive turn, not a chat).
+
+Both changes affect only the terminal surface — the VSCode extension still opens a chat with the unchanged prompt, and the shared diagnostics file is untouched.

--- a/.changeset/terminal-diagnosis-markdown-render.md
+++ b/.changeset/terminal-diagnosis-markdown-render.md
@@ -8,5 +8,6 @@ Claude replies in Markdown, which read poorly in the terminal — raw `##` headi
 
 - Renders that Markdown to coloured terminal text (bold yellow headings, bold emphasis, cyan inline/fenced code, bullets as `•`, and links collapsed to just their text).
 - Adapts the one-shot `claude -p` prompt so the reply is terminal-friendly: concise, `path:line` file references instead of Markdown links, and no closing question the user can't answer (this is a single non-interactive turn, not a chat).
+- Clarifies the handoff prompt's two options so it's obvious what each does: "Open a Claude Code chat to fix it" (in VSCode) vs "Just tell me what went wrong" (in terminal).
 
-Both changes affect only the terminal surface — the VSCode extension still opens a chat with the unchanged prompt, and the shared diagnostics file is untouched.
+These changes affect only the terminal surface — the VSCode extension still opens a chat with the unchanged prompt, and the shared diagnostics file is untouched.

--- a/docs/content/docs/Config/ai.mdx
+++ b/docs/content/docs/Config/ai.mdx
@@ -24,10 +24,11 @@ build logs, and pointers to the relevant rules) to
 `.graphics-kit/diagnostics/latest.md` and, when this is set to `'prompt'`, offers
 to hand it off to [Claude Code](https://claude.com/claude-code) to diagnose:
 
-- **Open a Claude Code session** — opens the Claude Code VSCode extension in a
-  chat next to your code, pre-filled with the diagnostics (you review and press
-  Enter).
-- **Ask Claude what went wrong** — runs a one-shot diagnosis in your terminal.
+- **Open a Claude Code chat to fix it** — opens the Claude Code VSCode extension
+  in a chat next to your code, pre-filled with the diagnostics (you review and
+  press Enter). It can read your project, find the cause, and fix it with you.
+- **Just tell me what went wrong** — runs a one-shot, read-only diagnosis in
+  your terminal.
 
 Set it to `'off'` to never show the prompt.
 

--- a/docs/content/docs/Notes/ai-in-the-loop.mdx
+++ b/docs/content/docs/Notes/ai-in-the-loop.mdx
@@ -15,8 +15,8 @@ Uploads and builds sometimes fail. Usually it's a real bug in your code, buried 
 
 Now, when a publisher command fails, we hand the problem to [Claude Code](https://claude.com/claude-code). The publisher writes a diagnostics file — the error, the likely cause pulled from your build logs and pointers to the publisher's own rules — then offers two ways you can use it with AI:
 
-- **Open a Claude Code session:** The VSCode extension opens a chat right next to your code, pre-filled and ready. It can read your project files and the error diagnostics, find the real cause and propose a fix in the chat. (And it won't edit files until you confirm you want to.)
-- **Ask Claude what went wrong:** Sends the error diagnostics to Claude in your terminal and prints back a quick, read-only synopsis of what the likeliest cause is.
+- **Open a Claude Code chat to fix it:** The VSCode extension opens a chat right next to your code, pre-filled and ready. It can read your project files and the error diagnostics, find the real cause and fix it with you in the chat. (And it won't edit files until you confirm you want to.)
+- **Just tell me what went wrong:** Sends the error diagnostics to Claude in your terminal and prints back a quick, read-only synopsis of the likeliest cause — it won't touch your files.
 
 No copying stack traces into a chat window. No guessing which log line matters. The agent starts with everything the publisher already knows about the failure, scoped to _your_ project — not generic advice.
 

--- a/src/diagnostics/handoff.test.ts
+++ b/src/diagnostics/handoff.test.ts
@@ -4,6 +4,7 @@ import {
   isAiEnabled,
   detectSurfaces,
   buildPointer,
+  buildTerminalPrompt,
   buildExtensionUrl,
   buildPromptMessage,
   isClaudeOnPath,
@@ -57,6 +58,18 @@ describe('buildPointer', () => {
     expect(buildPointer('/p/latest.md')).toBe(
       'Read /p/latest.md and diagnose the failure.'
     );
+  });
+});
+
+describe('buildTerminalPrompt', () => {
+  it('keeps the base pointer and appends terminal-only output guidance', () => {
+    const prompt = buildTerminalPrompt('/p/latest.md', 'upload');
+    // still points Claude at the same diagnostics file
+    expect(prompt).toContain(buildPointer('/p/latest.md', 'upload'));
+    // adapts the output for a one-shot, non-interactive terminal render
+    expect(prompt).toContain('path:line');
+    expect(prompt).toContain('do not ask a question');
+    expect(prompt).toMatch(/not a chat/i);
   });
 });
 

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -9,6 +9,7 @@ import open from 'open';
 import { utils } from '@reuters-graphics/graphics-bin';
 import { context } from '../context';
 import { reflowText } from '../utils/reflowText';
+import { renderMarkdownForTerminal } from './renderMarkdown';
 
 export interface HandoffOptions {
   /** Absolute path to the diagnostics file, or null if none was written. */
@@ -64,6 +65,25 @@ export const buildPointer = (
   command?: string
 ): string =>
   `Read ${diagnosticsPath} and diagnose the ${command ? `"${command}" ` : ''}failure.`;
+
+/**
+ * The prompt for the terminal `claude -p` diagnosis. It's the same pointer plus
+ * output guidance for a one-shot, non-interactive render — the VSCode extension
+ * opens a chat (Markdown renders, the user can reply) and keeps the plain
+ * pointer, so this adapts *only* the terminal surface without touching the
+ * shared diagnostics file.
+ */
+export const buildTerminalPrompt = (
+  diagnosticsPath: string,
+  command?: string
+): string =>
+  buildPointer(diagnosticsPath, command) +
+  '\n\nYour reply is printed directly into a terminal as a single, ' +
+  'non-interactive `claude -p` turn — this is not a chat, and the user cannot ' +
+  'reply. So: keep it concise; reference files as `path:line`, not Markdown ' +
+  'links; use only light Markdown (short headings, **bold**, `code`, and ' +
+  'hyphen bullets); and end with the concrete fix — do not ask a question or ' +
+  'offer to make the edit yourself.';
 
 /** The VSCode extension deep-link that pre-fills (but does not submit) the prompt. */
 export const buildExtensionUrl = (pointer: string): string =>
@@ -161,15 +181,17 @@ const isInteractive = (): boolean =>
   !!process.stdout.isTTY &&
   !!process.stdin.isTTY;
 
+/** Content width for a note: terminal width minus box chrome, capped for readability. */
+const noteWidth = (): number =>
+  Math.max(40, Math.min(process.stdout.columns ?? 80, 100) - 6);
+
 /**
  * Print a note, word-wrapping the message to the terminal width first. `note`
  * sizes its box to the longest line and does not wrap, so an LLM's long
  * unwrapped paragraph lines would otherwise blow the box past the terminal.
  */
 const reflowedNote = (message: string, title: string): void => {
-  // Leave room for the box chrome (`│  ` … `  │`); cap width for readability.
-  const width = Math.max(40, Math.min(process.stdout.columns ?? 80, 100) - 6);
-  note(reflowText(message, width).join('\n'), title);
+  note(reflowText(message, noteWidth()).join('\n'), title);
 };
 
 /**
@@ -203,7 +225,9 @@ const runTerminalDiagnosis = (pointer: string, bin: string): Promise<boolean> =>
       const text = Buffer.concat(out).toString('utf8').trim();
       if (code === 0 && text) {
         await s.stop('Claude looked at your error:');
-        reflowedNote(text, 'AI diagnosis');
+        // Claude replies in Markdown; render it to coloured terminal text
+        // rather than dumping raw ##/**/[]() syntax into the note.
+        note(renderMarkdownForTerminal(text, noteWidth()), 'AI diagnosis');
         resolve(true);
       } else {
         await s.stop("Claude couldn't diagnose the error.");
@@ -297,7 +321,12 @@ export const offerDiagnosisHandoff = async ({
     }
 
     if (choice === 'terminal' && claudeBin) {
-      const ok = await runTerminalDiagnosis(pointer, claudeBin);
+      // Terminal-specific prompt (one-shot, no Markdown links, no closing
+      // question); the extension above keeps the plain `pointer`.
+      const ok = await runTerminalDiagnosis(
+        buildTerminalPrompt(diagnosticsPath, command),
+        claudeBin
+      );
       if (!ok) copyPasteNote();
       return ok;
     }

--- a/src/diagnostics/handoff.ts
+++ b/src/diagnostics/handoff.ts
@@ -284,14 +284,14 @@ export const offerDiagnosisHandoff = async ({
     if (surfaces.extension)
       options.push({
         value: 'extension',
-        label: 'Open a Claude Code session to diagnose & fix it',
-        hint: 'VSCode extension',
+        label: 'Open a Claude Code chat to fix it',
+        hint: 'in VSCode',
       });
     if (surfaces.terminal)
       options.push({
         value: 'terminal',
-        label: 'Ask Claude what went wrong',
-        hint: 'claude in terminal',
+        label: 'Just tell me what went wrong',
+        hint: 'in terminal',
       });
     options.push({ value: 'no', label: 'No thanks' });
 

--- a/src/diagnostics/renderMarkdown.test.ts
+++ b/src/diagnostics/renderMarkdown.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdownForTerminal } from './renderMarkdown';
+
+// Colour is disabled in the (non-TTY) test env, so assert on the semantic
+// transformation — syntax stripped, text preserved — not on ANSI codes.
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('renderMarkdownForTerminal', () => {
+  it('turns a heading into text without the # markers', () => {
+    const out = renderMarkdownForTerminal('## Diagnosis');
+    expect(stripAnsi(out)).toBe('Diagnosis');
+    expect(out).not.toContain('#');
+  });
+
+  it('styles **bold** and drops the asterisks', () => {
+    const out = renderMarkdownForTerminal('The **root cause** is clear');
+    expect(stripAnsi(out)).toBe('The root cause is clear');
+    expect(out).not.toContain('**');
+  });
+
+  it('collapses a Markdown link to its text and drops the URL', () => {
+    const out = renderMarkdownForTerminal(
+      'See [page-building.md:84](node_modules/x/llms/page-building.md).'
+    );
+    const plain = stripAnsi(out);
+    expect(plain).toContain('page-building.md:84');
+    expect(plain).not.toContain('node_modules');
+    expect(plain).not.toContain('](');
+  });
+
+  it('styles inline code and keeps its text', () => {
+    const out = renderMarkdownForTerminal('Add the `SEO` component');
+    expect(stripAnsi(out)).toBe('Add the SEO component');
+    expect(out).not.toContain('`');
+  });
+
+  it('renders a bullet with a • and no leading dash', () => {
+    const out = renderMarkdownForTerminal('- first item');
+    const plain = stripAnsi(out);
+    expect(plain).toContain('• first item');
+    expect(plain).not.toMatch(/^\s*-\s/);
+  });
+
+  it('drops code-fence markers and keeps the code body', () => {
+    const out = renderMarkdownForTerminal('```svelte\nconsole.log(x);\n```');
+    const plain = stripAnsi(out);
+    expect(plain).toContain('console.log(x);');
+    expect(plain).not.toContain('```');
+    expect(plain).not.toContain('svelte');
+  });
+
+  it('wraps long prose to the given width (visible width, ignoring ANSI)', () => {
+    const long = `The ${'**map**'} embed ${'`+page.svelte`'} is missing the SEO component so no og image tag is emitted during the prerender pass here`;
+    const out = renderMarkdownForTerminal(long, 40);
+    for (const line of out.split('\n')) {
+      expect(stripAnsi(line).length).toBeLessThanOrEqual(40);
+    }
+  });
+});

--- a/src/diagnostics/renderMarkdown.ts
+++ b/src/diagnostics/renderMarkdown.ts
@@ -1,0 +1,64 @@
+import picocolors from 'picocolors';
+import { reflowText } from '../utils/reflowText';
+
+/**
+ * Resolve inline Markdown to terminal styling: links to their text, bold to
+ * bold, inline code to cyan. Applied per already-wrapped line, so a token that
+ * happens to straddle a wrap boundary is simply left as-is rather than mangled.
+ */
+const renderInline = (s: string): string =>
+  s
+    // [text](url) → text (drop the URL; terminals can't click it anyway)
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    // **bold** / __bold__ → bold
+    .replace(/\*\*([^*]+)\*\*/g, (_m, t) => picocolors.bold(t))
+    .replace(/__([^_]+)__/g, (_m, t) => picocolors.bold(t))
+    // `code` → cyan
+    .replace(/`([^`]+)`/g, (_m, t) => picocolors.cyan(t));
+
+/**
+ * Render an LLM's Markdown answer as terminal-friendly text: colour and bold in
+ * place of raw `##`/`**`/`[]()` syntax. Headings and bold become bold, inline
+ * code and fenced code become cyan, links collapse to their text, and bullets
+ * get a coloured •.
+ *
+ * The text is wrapped to `width` *first* (on the plain Markdown, so the width
+ * math is right), then styled line by line — styling only strips syntax and
+ * adds invisible ANSI, so no rendered line ends up wider than the wrap.
+ */
+export const renderMarkdownForTerminal = (md: string, width = 100): string => {
+  const rendered: string[] = [];
+  let inFence = false;
+
+  for (const line of reflowText(md.trim(), width)) {
+    // Fenced code: drop the ``` markers, colour the body, skip inline parsing.
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      rendered.push(picocolors.cyan(line));
+      continue;
+    }
+
+    const heading = line.match(/^\s*#{1,6}\s+(.*)$/);
+    if (heading) {
+      rendered.push(
+        picocolors.yellow(picocolors.bold(renderInline(heading[1])))
+      );
+      continue;
+    }
+
+    const bullet = line.match(/^(\s*)[-*]\s+(.*)$/);
+    if (bullet) {
+      rendered.push(
+        `${bullet[1]}${picocolors.cyan('•')} ${renderInline(bullet[2])}`
+      );
+      continue;
+    }
+
+    rendered.push(renderInline(line));
+  }
+
+  return rendered.join('\n');
+};


### PR DESCRIPTION
Improves the terminal AI-diagnosis output, which showed Claude's raw Markdown (`##` headings, `**bold**`, `[text](url)` links, code fences) with no colour and a dangling "Want me to apply…?" question the user couldn't answer.

## Changes

**Markdown → terminal renderer** ([renderMarkdown.ts](src/diagnostics/renderMarkdown.ts))
Renders Claude's Markdown to coloured terminal text: **bold yellow** headings, bold emphasis, cyan inline/fenced code, bullets as `•`, and links collapsed to just their text (no URL). Wraps the plain text first (correct width math), then styles per line — styling only strips syntax and adds invisible ANSI, so no rendered line exceeds the wrap and the note box stays aligned.

**Terminal-only prompt adaptation** ([handoff.ts](src/diagnostics/handoff.ts))
`buildTerminalPrompt` appends guidance for the one-shot `claude -p` render: be concise, reference files as `path:line` (not Markdown links), and don't end with a question or offer to make edits — it's a single non-interactive turn, not a chat.

**Clearer handoff options + docs**
Reworded the two surfaces so the choice reads as fix-it vs explain-it: "Open a Claude Code chat to fix it" (in VSCode) vs "Just tell me what went wrong" (in terminal). Updated the `ai` config and ai-in-the-loop docs to match.

## Scope
All of this is **terminal-surface only** — the VSCode extension still opens a chat with the unchanged prompt (Markdown renders natively there), and the shared `latest.md` diagnostics file is untouched. No second file per surface.

## Tests
New `renderMarkdown` tests (headings, bold, links, code, bullets, fences, width) and a `buildTerminalPrompt` test. 194 tests pass; tsc + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)