### PR TITLE
ci: dispatch dependency-updated to bluprint_svelte5-sreps on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,3 +28,10 @@ jobs:
           token: ${{ secrets.REPO_PAT_TOKEN }}
           repository: reuters-graphics/bluprint_graphics-kit
           event-type: dependency-updated
+
+      - name: Dispatch to bluprint_svelte5-sreps
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.REPO_PAT_TOKEN }}
+          repository: reuters-graphics/bluprint_svelte5-sreps
+          event-type: dependency-updated


### PR DESCRIPTION
## Summary
- Adds a second `repository-dispatch` step alongside the existing `bluprint_graphics-kit` one, so `bluprint_svelte5-sreps`'s update-dependencies workflow (which listens for this event but currently has no sender) actually fires.

## Test plan
- [ ] Confirm `REPO_PAT_TOKEN` has write access to `reuters-graphics/bluprint_svelte5-sreps`
- [ ] Merge and confirm the next release triggers a PR in `bluprint_svelte5-sreps`